### PR TITLE
Force manual updates

### DIFF
--- a/wp-admin/includes/class-wp-site-health.php
+++ b/wp-admin/includes/class-wp-site-health.php
@@ -266,6 +266,24 @@ class WP_Site_Health {
 			'test'        => 'retraceur_version',
 		);
 
+		if ( ! retraceur_is_updater_enabled() ) {
+			$result['status'] = 'recommended';
+			$result['label']  = __( 'The Retraceur automatic update feature is not available yet' );
+
+			$result['description'] = sprintf(
+				'<p>%s</p>',
+				__( 'In the meantime, please: do often check for updates manually.' )
+			);
+
+			$result['actions'] = sprintf(
+				'<a href="%s" target="_blank">%s</a>',
+				'https://github.com/retraceur/coeur/releases',
+				__( 'Check for updates manually' )
+			);
+
+			return $result;
+		}
+
 		$core_current_version = retraceur_get_version();
 		$core_updates         = get_core_updates();
 

--- a/wp-admin/includes/update.php
+++ b/wp-admin/includes/update.php
@@ -269,11 +269,14 @@ function core_update_footer( $msg = '' ) {
 	$is_development_version = preg_match( '/alpha|beta|RC/', retraceur_get_version() );
 
 	if ( $is_development_version ) {
+		$is_updater_enabled = retraceur_is_updater_enabled();
+
 		return sprintf(
-			/* translators: 1: Retraceur version number, 2: URL to Retraceur Updates screen. */
-			__( 'You are using a development version (%1$s). Cool! Please <a href="%2$s">stay updated</a>.' ),
+			/* translators: 1: Retraceur version number, 2: URL to Retraceur Updates screen. 3: Link target attribute. */
+			__( 'You are using a development version (%1$s). Cool! Please <a href="%2$s"%3$s>stay updated</a>.' ),
 			retraceur_get_version(),
-			network_admin_url( 'update-core.php' )
+			$is_updater_enabled ? network_admin_url( 'update-core.php' ) : 'https://github.com/retraceur/coeur/releases',
+			$is_updater_enabled ? '' : ' target="_blank"'
 		);
 	}
 

--- a/wp-admin/menu.php
+++ b/wp-admin/menu.php
@@ -31,7 +31,7 @@ if ( ! is_multisite() || current_user_can( 'update_core' ) ) {
 	$update_data = wp_get_update_data();
 }
 
-if ( ! is_multisite() ) {
+if ( ! is_multisite() && retraceur_is_updater_enabled() ) {
 	if ( current_user_can( 'update_core' ) ) {
 		$cap = 'update_core';
 	} elseif ( current_user_can( 'update_plugins' ) ) {

--- a/wp-admin/update-core.php
+++ b/wp-admin/update-core.php
@@ -384,11 +384,14 @@ function core_auto_updates_settings() {
 
 	<p class="auto-update-status">
 		<?php
-
+		/*
+		 * Disable this for now.
+		 * @todo Restore when the Retraceur Update API will be ready.
+		 *
 		if ( $updater->is_vcs_checkout( ABSPATH ) ) {
-			_e( 'This site appears to be under version control. Automatic updates are disabled.' );
+			esc_html_e( 'This site appears to be under version control. Automatic updates are disabled.' );
 		} elseif ( $upgrade_major ) {
-			_e( 'This site is automatically kept up to date with each new version of Retraceur.' );
+			esc_html_e( 'This site is automatically kept up to date with each new version of Retraceur.' );
 
 			if ( $can_set_update_option ) {
 				echo '<br />';
@@ -399,7 +402,7 @@ function core_auto_updates_settings() {
 				);
 			}
 		} elseif ( $upgrade_minor ) {
-			_e( 'This site is automatically kept up to date with maintenance and security releases of Retraceur only.' );
+			esc_html_e( 'This site is automatically kept up to date with maintenance and security releases of Retraceur only.' );
 
 			if ( $can_set_update_option ) {
 				echo '<br />';
@@ -410,8 +413,18 @@ function core_auto_updates_settings() {
 				);
 			}
 		} else {
-			_e( 'This site will not receive automatic updates for new versions of Retraceur.' );
+			esc_html_e( 'This site will not receive automatic updates for new versions of Retraceur.' );
 		}
+		*/
+		?>
+		<strong><?php esc_html_e( 'The Retraceur automatic update feature is not available yet' ); ?></strong><br />
+		<?php esc_html_e( 'In the meantime, please: do often check for updates manually.' ); ?><br />
+		<?php
+		printf(
+			'<a href="%s" target="_blank">%s</a>',
+			'https://github.com/retraceur/coeur/releases',
+			esc_html__( 'Check for updates manually' )
+		);
 		?>
 	</p>
 
@@ -914,7 +927,8 @@ if ( ( 'do-theme-upgrade' === $action || ( 'do-plugin-upgrade' === $action && ! 
 $title       = __( 'Retraceur Updates' );
 $parent_file = 'index.php';
 
-$updates_overview  = '<p>' . __( 'On this screen, you can update to the latest version of Retraceur, as well as update your themes, plugins, and translations.' ) . '</p>';
+// @todo Restore when the Retraceur Update API will be ready.
+$updates_overview  = ''; // '<p>' . __( 'On this screen, you can update to the latest version of Retraceur, as well as update your themes, plugins, and translations.' ) . '</p>';
 $updates_overview .= '<p>' . __( 'If an update is available, you&#8127;ll see a notification appear in the Toolbar and navigation menu.' ) . ' ' . __( 'Keeping your site updated is important for security. It also makes the internet a safer place for you and your readers.' ) . '</p>';
 
 get_current_screen()->add_help_tab(
@@ -932,6 +946,10 @@ if ( 'en_US' !== get_locale() ) {
 	$updates_howto .= '<p>' . __( '<strong>Translations</strong> &mdash; The files translating Retraceur into your language are updated for you whenever any other updates occur. But if these files are out of date, you can <strong>click the &#8220;Update Translations&#8221;</strong> button.' ) . '</p>';
 }
 
+/*
+ * Disable this for now.
+ * @todo Restore when the Retraceur Update API will be ready.
+ *
 get_current_screen()->add_help_tab(
 	array(
 		'id'      => 'how-to-update',
@@ -939,6 +957,7 @@ get_current_screen()->add_help_tab(
 		'content' => $updates_howto,
 	)
 );
+*/
 
 if ( 'upgrade-core' === $action ) {
 	// Force an update check when requested.
@@ -948,7 +967,12 @@ if ( 'upgrade-core' === $action ) {
 	require_once ABSPATH . 'wp-admin/admin-header.php';
 	?>
 	<div class="wrap">
-	<h1><?php _e( 'Retraceur Updates' ); ?></h1>
+	<h1><?php esc_html_e( 'Retraceur Updates' ); ?></h1>
+	<?php
+	/*
+	 * Disable this for now.
+	 * @todo Restore when the Retraceur Update API will be ready.
+	 *
 	<p><?php _e( 'Updates may take several minutes to complete. If there is no feedback after 5 minutes, or if there are errors please refer to the Help section above.' ); ?></p>
 
 	<?php
@@ -982,29 +1006,39 @@ if ( 'upgrade-core' === $action ) {
 	if ( $current && isset( $current->last_checked ) ) {
 		$last_update_check = $current->last_checked + (int) ( (float) get_option( 'gmt_offset' ) * HOUR_IN_SECONDS );
 	}
-
+	*/
 	echo '<h2 class="wp-current-version">';
 	/* translators: Current version of Retraceur. */
 	printf( __( 'Current version: %s' ), esc_html( retraceur_get_version() ) );
 	echo '</h2>';
 
+	/*
+	 * Disable this for now.
+	 * @todo Restore when the Retraceur Update API will be ready.
+	 *
 	echo '<p class="update-last-checked">';
 
 	printf(
-		/* translators: 1: Date, 2: Time. */
+		// translators: 1: Date, 2: Time.
 		__( 'Last checked on %1$s at %2$s.' ),
-		/* translators: Default date format, see https://www.php.net/manual/datetime.format.php */
+		// translators: Default date format, see https://www.php.net/manual/datetime.format.php
 		date_i18n( __( 'F j, Y' ), $last_update_check ),
-		/* translators: Last update time format, see https://www.php.net/manual/datetime.format.php */
+		// translators: Last update time format, see https://www.php.net/manual/datetime.format.php
 		date_i18n( __( 'g:i a T' ), $last_update_check )
 	);
 	echo ' <a href="' . esc_url( self_admin_url( 'update-core.php?force-check=1' ) ) . '">' . __( 'Check again.' ) . '</a>';
 	echo '</p>';
+	*/
 
 	if ( current_user_can( 'update_core' ) ) {
 		core_auto_updates_settings();
-		core_upgrade_preamble();
+		//core_upgrade_preamble();
 	}
+
+	/*
+	 * Disable this for now.
+	 * @todo Restore when the Retraceur Update API will be ready.
+	 *
 	if ( current_user_can( 'update_plugins' ) ) {
 		list_plugin_updates();
 	}
@@ -1014,6 +1048,7 @@ if ( 'upgrade-core' === $action ) {
 	if ( current_user_can( 'update_languages' ) ) {
 		list_translation_updates();
 	}
+	*/
 
 	/**
 	 * Fires after the core, plugin, and theme update tables.

--- a/wp-includes/update.php
+++ b/wp-includes/update.php
@@ -794,6 +794,22 @@ function wp_get_translation_updates() {
 }
 
 /**
+ * Checks whether the Automatic Updater is enabled or not.
+ *
+ * @since 1.0.0 Retraceur fork.
+ *
+ * @return boolean True if the Automatic Updater is enabled. False otherwise.
+ */
+function retraceur_is_updater_enabled() {
+	if ( ! class_exists( 'WP_Automatic_Updater' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/class-wp-automatic-updater.php';
+	}
+
+	$updater = new WP_Automatic_Updater();
+	return ! $updater->is_disabled();
+}
+
+/**
  * Collects counts and UI strings for available updates.
  *
  * @since WP 3.3.0


### PR DESCRIPTION
- Disable the `update-core` Admin Menu
- Use the repository's GitHub Releases page as a way to be informed of latest available updates.
- Trick Site Health test to inform manual checks are importants.

See #30 
Fixes #51 