### PR TITLE
Build Coeur Update API

### DIFF
--- a/wp-admin/includes/admin-filters.php
+++ b/wp-admin/includes/admin-filters.php
@@ -129,10 +129,24 @@ add_action( 'admin_notices', 'wp_recovery_mode_nag', 1 );
 add_filter( 'update_footer', 'core_update_footer' );
 
 // Upgrade hooks.
-add_action( 'upgrader_process_complete', array( 'Language_Pack_Upgrader', 'async_upgrade' ), 20 );
+
+/**
+ * @todo Restore when Retraceur adpated its API to handle it.
+ */
+// add_action( 'upgrader_process_complete', array( 'Language_Pack_Upgrader', 'async_upgrade' ), 20 );
+
+// Only keep Coeur upgrade checks.
 add_action( 'upgrader_process_complete', 'retraceur_version_check', 10, 0 );
-add_action( 'upgrader_process_complete', 'wp_update_plugins', 10, 0 );
-add_action( 'upgrader_process_complete', 'wp_update_themes', 10, 0 );
+
+/**
+ * @todo Restore when Retraceur adpated its API to handle it.
+ */
+// add_action( 'upgrader_process_complete', 'wp_update_plugins', 10, 0 );
+
+/**
+ * @todo Restore when Retraceur adpated its API to handle it.
+ */
+// add_action( 'upgrader_process_complete', 'wp_update_themes', 10, 0 );
 
 // Privacy hooks.
 add_filter( 'wp_privacy_personal_data_erasure_page', 'wp_privacy_process_personal_data_erasure_page', 10, 5 );

--- a/wp-admin/includes/admin-filters.php
+++ b/wp-admin/includes/admin-filters.php
@@ -123,7 +123,6 @@ add_action( 'admin_notices', 'update_nag', 3 );
 add_action( 'admin_notices', 'deactivated_plugins_notice', 5 );
 add_action( 'admin_notices', 'paused_plugins_notice', 5 );
 add_action( 'admin_notices', 'paused_themes_notice', 5 );
-add_action( 'admin_notices', 'maintenance_nag', 10 );
 add_action( 'admin_notices', 'wp_recovery_mode_nag', 1 );
 
 add_filter( 'update_footer', 'core_update_footer' );

--- a/wp-admin/includes/admin-filters.php
+++ b/wp-admin/includes/admin-filters.php
@@ -130,7 +130,7 @@ add_filter( 'update_footer', 'core_update_footer' );
 
 // Upgrade hooks.
 add_action( 'upgrader_process_complete', array( 'Language_Pack_Upgrader', 'async_upgrade' ), 20 );
-add_action( 'upgrader_process_complete', 'wp_version_check', 10, 0 );
+add_action( 'upgrader_process_complete', 'retraceur_version_check', 10, 0 );
 add_action( 'upgrader_process_complete', 'wp_update_plugins', 10, 0 );
 add_action( 'upgrader_process_complete', 'wp_update_themes', 10, 0 );
 

--- a/wp-admin/includes/class-core-upgrader.php
+++ b/wp-admin/includes/class-core-upgrader.php
@@ -21,6 +21,7 @@
  *
  * @since WP 2.8.0
  * @since WP 4.6.0 Moved to its own file from wp-admin/includes/class-wp-upgrader.php.
+ * @since 1.0.0 Retraceur fork.
  *
  * @see WP_Upgrader
  */
@@ -48,6 +49,7 @@ class Core_Upgrader extends WP_Upgrader {
 	 * Upgrades Retraceur core.
 	 *
 	 * @since WP 2.8.0
+	 * @since 2.0.0 Retraceur fork. Adaptations were made compared to how WP handles an upgrade.
 	 *
 	 * @global WP_Filesystem_Base $wp_filesystem                Retraceur filesystem subclass.
 	 * @global callable           $_wp_filesystem_direct_method
@@ -70,8 +72,7 @@ class Core_Upgrader extends WP_Upgrader {
 
 		require ABSPATH . WPINC . '/version.php'; // $retraceur_version;
 
-		$start_time = time();
-
+		$start_time  = time();
 		$defaults    = array(
 			'pre_check_md5'                => false,
 			'attempt_rollback'             => false,
@@ -94,32 +95,6 @@ class Core_Upgrader extends WP_Upgrader {
 		}
 
 		$wp_dir = trailingslashit( $wp_filesystem->abspath() );
-
-		/*$partial = true;
-		if ( $parsed_args['do_rollback'] ) {
-			$partial = false;
-		} elseif ( $parsed_args['pre_check_md5'] && ! $this->check_files() ) {
-			$partial = false;
-		}*/
-
-		/*
-		 * If partial update is returned from the API, use that, unless we're doing
-		 * a reinstallation. If we cross the new_bundled version number, then use
-		 * the new_bundled zip. Don't though if the constant is set to skip bundled items.
-		 * If the API returns a no_content zip, go with it. Finally, default to the full zip.
-		 */
-		/*if ( $parsed_args['do_rollback'] && $current->packages->rollback ) {
-			$to_download = 'rollback';
-		} elseif ( $current->packages->partial && 'reinstall' !== $current->response && $retraceur_version === $current->partial_version && $partial ) {
-			$to_download = 'partial';
-		} elseif ( $current->packages->new_bundled && version_compare( $retraceur_version, $current->new_bundled, '<' )
-			&& ( ! defined( 'CORE_UPGRADE_SKIP_NEW_BUNDLED' ) || ! CORE_UPGRADE_SKIP_NEW_BUNDLED ) ) {
-			$to_download = 'new_bundled';
-		} elseif ( $current->packages->no_content ) {
-			$to_download = 'no_content';
-		} else {
-			$to_download = 'full';
-		}*/
 
 		// Lock to prevent multiple Core Updates occurring.
 		$lock = WP_Upgrader::create_lock( 'core_updater', 15 * MINUTE_IN_SECONDS );
@@ -284,6 +259,7 @@ class Core_Upgrader extends WP_Upgrader {
 		 * Filters whether to enable major automatic core updates.
 		 *
 		 * @since WP 3.7.0
+		 * @deprecated 2.0.0 Retraceur fork.
 		 *
 		 * @param bool $upgrade_major Whether to enable major automatic core updates.
 		 */

--- a/wp-admin/includes/class-core-upgrader.php
+++ b/wp-admin/includes/class-core-upgrader.php
@@ -220,7 +220,7 @@ class Core_Upgrader extends WP_Upgrader {
 	public static function should_update_to_version( $offered_ver ) {
 		_deprecated_function( __METHOD__, '2.0.0', '', true );
 
-		$not_supported = __( 'The WP Auto Updates feature is not used by Retraceur fork.' );
+		$not_supported = __( 'The WP Background Updates feature is not used by Retraceur fork.' );
 
 		/**
 		 * Filters whether to enable automatic core updates for development versions.
@@ -271,7 +271,7 @@ class Core_Upgrader extends WP_Upgrader {
 			$not_supported
 		);
 
-		// The WP Auto Updates is not used by Retraceur fork.
+		// The WP Background Updates feature is not used by Retraceur fork.
 		return false;
 	}
 

--- a/wp-admin/includes/class-core-upgrader.php
+++ b/wp-admin/includes/class-core-upgrader.php
@@ -73,7 +73,7 @@ class Core_Upgrader extends WP_Upgrader {
 		$start_time = time();
 
 		$defaults    = array(
-			'pre_check_md5'                => true,
+			'pre_check_md5'                => false,
 			'attempt_rollback'             => false,
 			'do_rollback'                  => false,
 			'allow_relaxed_file_ownership' => false,
@@ -95,12 +95,12 @@ class Core_Upgrader extends WP_Upgrader {
 
 		$wp_dir = trailingslashit( $wp_filesystem->abspath() );
 
-		$partial = true;
+		/*$partial = true;
 		if ( $parsed_args['do_rollback'] ) {
 			$partial = false;
 		} elseif ( $parsed_args['pre_check_md5'] && ! $this->check_files() ) {
 			$partial = false;
-		}
+		}*/
 
 		/*
 		 * If partial update is returned from the API, use that, unless we're doing
@@ -108,7 +108,7 @@ class Core_Upgrader extends WP_Upgrader {
 		 * the new_bundled zip. Don't though if the constant is set to skip bundled items.
 		 * If the API returns a no_content zip, go with it. Finally, default to the full zip.
 		 */
-		if ( $parsed_args['do_rollback'] && $current->packages->rollback ) {
+		/*if ( $parsed_args['do_rollback'] && $current->packages->rollback ) {
 			$to_download = 'rollback';
 		} elseif ( $current->packages->partial && 'reinstall' !== $current->response && $retraceur_version === $current->partial_version && $partial ) {
 			$to_download = 'partial';
@@ -119,7 +119,7 @@ class Core_Upgrader extends WP_Upgrader {
 			$to_download = 'no_content';
 		} else {
 			$to_download = 'full';
-		}
+		}*/
 
 		// Lock to prevent multiple Core Updates occurring.
 		$lock = WP_Upgrader::create_lock( 'core_updater', 15 * MINUTE_IN_SECONDS );
@@ -127,7 +127,7 @@ class Core_Upgrader extends WP_Upgrader {
 			return new WP_Error( 'locked', $this->strings['locked'] );
 		}
 
-		$download = $this->download_package( $current->packages->$to_download, false );
+		$download = $this->download_package( $current->download, false );
 
 		/*
 		 * Allow for signature soft-fail.
@@ -153,7 +153,7 @@ class Core_Upgrader extends WP_Upgrader {
 			return $working_dir;
 		}
 
-		// Copy update-core.php from the new version into place.
+		/* Copy update-core.php from the new version into place.
 		if ( ! $wp_filesystem->copy( $working_dir . '/retraceur/wp-admin/includes/update-core.php', $wp_dir . 'wp-admin/includes/update-core.php', true ) ) {
 			$wp_filesystem->delete( $working_dir, true );
 			WP_Upgrader::release_lock( 'core_updater' );
@@ -181,7 +181,7 @@ class Core_Upgrader extends WP_Upgrader {
 				 * mkdir_failed__copy_dir, copy_failed__copy_dir_retry, and disk_full.
 				 * do_rollback allows for update_core() to trigger a rollback if needed.
 				 */
-				if ( str_contains( $error_code, 'do_rollback' ) ) {
+				/*if ( str_contains( $error_code, 'do_rollback' ) ) {
 					$try_rollback = true;
 				} elseif ( str_contains( $error_code, '__copy_dir' ) ) {
 					$try_rollback = true;
@@ -192,10 +192,10 @@ class Core_Upgrader extends WP_Upgrader {
 
 			if ( $try_rollback ) {
 				/** This filter is documented in wp-admin/includes/update-core.php */
-				apply_filters( 'update_feedback', $result );
+				/*apply_filters( 'update_feedback', $result );
 
 				/** This filter is documented in wp-admin/includes/update-core.php */
-				apply_filters( 'update_feedback', $this->strings['start_rollback'] );
+				/*apply_filters( 'update_feedback', $this->strings['start_rollback'] );
 
 				$rollback_result = $this->upgrade( $current, array_merge( $parsed_args, array( 'do_rollback' => true ) ) );
 
@@ -212,7 +212,7 @@ class Core_Upgrader extends WP_Upgrader {
 		}
 
 		/** This action is documented in wp-admin/includes/class-wp-upgrader.php */
-		do_action(
+		/*do_action(
 			'upgrader_process_complete',
 			$this,
 			array(
@@ -255,11 +255,11 @@ class Core_Upgrader extends WP_Upgrader {
 			}
 
 			wp_version_check( $stats );
-		}
+		}*/
 
 		WP_Upgrader::release_lock( 'core_updater' );
 
-		return $result;
+		return $working_dir; //$result;
 	}
 
 	/**

--- a/wp-admin/includes/class-core-upgrader.php
+++ b/wp-admin/includes/class-core-upgrader.php
@@ -222,39 +222,10 @@ class Core_Upgrader extends WP_Upgrader {
 		);
 
 		// Clear the current updates.
-		delete_site_transient( 'update_core' );
+		delete_site_transient( 'update_coeur' );
 
 		if ( ! $parsed_args['do_rollback'] ) {
-			$stats = array(
-				'update_type'      => $current->response,
-				'success'          => true,
-				'fs_method'        => $wp_filesystem->method,
-				'fs_method_forced' => defined( 'FS_METHOD' ) || has_filter( 'filesystem_method' ),
-				'fs_method_direct' => ! empty( $GLOBALS['_wp_filesystem_direct_method'] ) ? $GLOBALS['_wp_filesystem_direct_method'] : '',
-				'time_taken'       => time() - $start_time,
-				'reported'         => $retraceur_version,
-				'attempted'        => $current->version,
-			);
-
-			if ( is_wp_error( $result ) ) {
-				$stats['success'] = false;
-				// Did a rollback occur?
-				if ( ! empty( $try_rollback ) ) {
-					$stats['error_code'] = $original_result->get_error_code();
-					$stats['error_data'] = $original_result->get_error_data();
-					// Was the rollback successful? If not, collect its error too.
-					$stats['rollback'] = ! is_wp_error( $rollback_result );
-					if ( is_wp_error( $rollback_result ) ) {
-						$stats['rollback_code'] = $rollback_result->get_error_code();
-						$stats['rollback_data'] = $rollback_result->get_error_data();
-					}
-				} else {
-					$stats['error_code'] = $result->get_error_code();
-					$stats['error_data'] = $result->get_error_data();
-				}
-			}
-
-			wp_version_check( $stats );
+			retraceur_version_check();
 		}
 
 		WP_Upgrader::release_lock( 'core_updater' );
@@ -266,121 +237,65 @@ class Core_Upgrader extends WP_Upgrader {
 	 * Determines if this Retraceur Core version should update to an offered version or not.
 	 *
 	 * @since WP 3.7.0
+	 * @deprecated 2.0.0 Retraceur fork.
 	 *
 	 * @param string $offered_ver The offered version, of the format x.y.z.
 	 * @return bool True if we should update to the offered version, otherwise false.
 	 */
 	public static function should_update_to_version( $offered_ver ) {
-		require ABSPATH . WPINC . '/version.php'; // $retraceur_version; // x.y.z
+		_deprecated_function( __METHOD__, '2.0.0', '', true );
 
-		$current_branch = implode( '.', array_slice( preg_split( '/[.-]/', $retraceur_version ), 0, 2 ) ); // x.y
-		$new_branch     = implode( '.', array_slice( preg_split( '/[.-]/', $offered_ver ), 0, 2 ) ); // x.y
+		$not_supported = __( 'The WP Auto Updates feature is not used by Retraceur fork.' );
 
-		$current_is_development_version = (bool) strpos( $retraceur_version, '-' );
+		/**
+		 * Filters whether to enable automatic core updates for development versions.
+		 *
+		 * @since WP 3.7.0
+		 * @deprecated 2.0.0 Retraceur fork.
+		 *
+		 * @param bool $upgrade_dev Whether to enable automatic updates for
+		 *                          development versions.
+		 */
+		apply_filters_deprecated(
+			'allow_dev_auto_core_updates',
+			array( false ),
+			'2.0.0',
+			'',
+			$not_supported
+		);
 
-		// Defaults:
-		$upgrade_dev   = get_site_option( 'auto_update_core_dev', 'enabled' ) === 'enabled';
-		$upgrade_minor = get_site_option( 'auto_update_core_minor', 'enabled' ) === 'enabled';
-		$upgrade_major = get_site_option( 'auto_update_core_major', 'unset' ) === 'enabled';
+		/**
+		 * Filters whether to enable minor automatic core updates.
+		 *
+		 * @since WP 3.7.0
+		 * @deprecated 2.0.0 Retraceur fork.
+		 *
+		 * @param bool $upgrade_minor Whether to enable minor automatic core updates.
+		 */
+		apply_filters_deprecated(
+			'allow_minor_auto_core_updates',
+			array( false ),
+			'2.0.0',
+			'',
+			$not_supported
+		);
 
-		// WP_AUTO_UPDATE_CORE = true (all), 'beta', 'rc', 'development', 'branch-development', 'minor', false.
-		if ( defined( 'WP_AUTO_UPDATE_CORE' ) ) {
-			if ( false === WP_AUTO_UPDATE_CORE ) {
-				// Defaults to turned off, unless a filter allows it.
-				$upgrade_dev   = false;
-				$upgrade_minor = false;
-				$upgrade_major = false;
-			} elseif ( true === WP_AUTO_UPDATE_CORE
-				|| in_array( WP_AUTO_UPDATE_CORE, array( 'beta', 'rc', 'development', 'branch-development' ), true )
-			) {
-				// ALL updates for core.
-				$upgrade_dev   = true;
-				$upgrade_minor = true;
-				$upgrade_major = true;
-			} elseif ( 'minor' === WP_AUTO_UPDATE_CORE ) {
-				// Only minor updates for core.
-				$upgrade_dev   = false;
-				$upgrade_minor = true;
-				$upgrade_major = false;
-			}
-		}
+		/**
+		 * Filters whether to enable major automatic core updates.
+		 *
+		 * @since WP 3.7.0
+		 *
+		 * @param bool $upgrade_major Whether to enable major automatic core updates.
+		 */
+		apply_filters_deprecated(
+			'allow_major_auto_core_updates',
+			array( false ),
+			'2.0.0',
+			'',
+			$not_supported
+		);
 
-		// 1: If we're already on that version, not much point in updating?
-		if ( $offered_ver === $retraceur_version ) {
-			return false;
-		}
-
-		// 2: If we're running a newer version, that's a nope.
-		if ( version_compare( $retraceur_version, $offered_ver, '>' ) ) {
-			return false;
-		}
-
-		$failure_data = get_site_option( 'auto_core_update_failed' );
-		if ( $failure_data ) {
-			// If this was a critical update failure, cannot update.
-			if ( ! empty( $failure_data['critical'] ) ) {
-				return false;
-			}
-
-			// Don't claim we can update on update-core.php if we have a non-critical failure logged.
-			if ( $retraceur_version === $failure_data['current'] && str_contains( $offered_ver, '.1.next.minor' ) ) {
-				return false;
-			}
-
-			/*
-			 * Cannot update if we're retrying the same A to B update that caused a non-critical failure.
-			 * Some non-critical failures do allow retries, like download_failed.
-			 * 3.7.1 => 3.7.2 resulted in files_not_writable, if we are still on 3.7.1 and still trying to update to 3.7.2.
-			 */
-			if ( empty( $failure_data['retry'] ) && $retraceur_version === $failure_data['current'] && $offered_ver === $failure_data['attempted'] ) {
-				return false;
-			}
-		}
-
-		// 3: 3.7-alpha-25000 -> 3.7-alpha-25678 -> 3.7-beta1 -> 3.7-beta2.
-		if ( $current_is_development_version ) {
-
-			/**
-			 * Filters whether to enable automatic core updates for development versions.
-			 *
-			 * @since WP 3.7.0
-			 *
-			 * @param bool $upgrade_dev Whether to enable automatic updates for
-			 *                          development versions.
-			 */
-			if ( ! apply_filters( 'allow_dev_auto_core_updates', $upgrade_dev ) ) {
-				return false;
-			}
-			// Else fall through to minor + major branches below.
-		}
-
-		// 4: Minor in-branch updates (3.7.0 -> 3.7.1 -> 3.7.2 -> 3.7.4).
-		if ( $current_branch === $new_branch ) {
-
-			/**
-			 * Filters whether to enable minor automatic core updates.
-			 *
-			 * @since WP 3.7.0
-			 *
-			 * @param bool $upgrade_minor Whether to enable minor automatic core updates.
-			 */
-			return apply_filters( 'allow_minor_auto_core_updates', $upgrade_minor );
-		}
-
-		// 5: Major version updates (3.7.0 -> 3.8.0 -> 3.9.1).
-		if ( version_compare( $new_branch, $current_branch, '>' ) ) {
-
-			/**
-			 * Filters whether to enable major automatic core updates.
-			 *
-			 * @since WP 3.7.0
-			 *
-			 * @param bool $upgrade_major Whether to enable major automatic core updates.
-			 */
-			return apply_filters( 'allow_major_auto_core_updates', $upgrade_major );
-		}
-
-		// If we're not sure, we don't want it.
+		// The WP Auto Updates is not used by Retraceur fork.
 		return false;
 	}
 

--- a/wp-admin/includes/class-core-upgrader.php
+++ b/wp-admin/includes/class-core-upgrader.php
@@ -153,7 +153,7 @@ class Core_Upgrader extends WP_Upgrader {
 			return $working_dir;
 		}
 
-		/* Copy update-core.php from the new version into place.
+		// Copy update-core.php from the new version into place.
 		if ( ! $wp_filesystem->copy( $working_dir . '/retraceur/wp-admin/includes/update-core.php', $wp_dir . 'wp-admin/includes/update-core.php', true ) ) {
 			$wp_filesystem->delete( $working_dir, true );
 			WP_Upgrader::release_lock( 'core_updater' );
@@ -181,7 +181,7 @@ class Core_Upgrader extends WP_Upgrader {
 				 * mkdir_failed__copy_dir, copy_failed__copy_dir_retry, and disk_full.
 				 * do_rollback allows for update_core() to trigger a rollback if needed.
 				 */
-				/*if ( str_contains( $error_code, 'do_rollback' ) ) {
+				if ( str_contains( $error_code, 'do_rollback' ) ) {
 					$try_rollback = true;
 				} elseif ( str_contains( $error_code, '__copy_dir' ) ) {
 					$try_rollback = true;
@@ -192,10 +192,10 @@ class Core_Upgrader extends WP_Upgrader {
 
 			if ( $try_rollback ) {
 				/** This filter is documented in wp-admin/includes/update-core.php */
-				/*apply_filters( 'update_feedback', $result );
+				apply_filters( 'update_feedback', $result );
 
 				/** This filter is documented in wp-admin/includes/update-core.php */
-				/*apply_filters( 'update_feedback', $this->strings['start_rollback'] );
+				apply_filters( 'update_feedback', $this->strings['start_rollback'] );
 
 				$rollback_result = $this->upgrade( $current, array_merge( $parsed_args, array( 'do_rollback' => true ) ) );
 
@@ -212,7 +212,7 @@ class Core_Upgrader extends WP_Upgrader {
 		}
 
 		/** This action is documented in wp-admin/includes/class-wp-upgrader.php */
-		/*do_action(
+		do_action(
 			'upgrader_process_complete',
 			$this,
 			array(
@@ -255,11 +255,11 @@ class Core_Upgrader extends WP_Upgrader {
 			}
 
 			wp_version_check( $stats );
-		}*/
+		}
 
 		WP_Upgrader::release_lock( 'core_updater' );
 
-		return $working_dir; //$result;
+		return $result;
 	}
 
 	/**

--- a/wp-admin/includes/class-language-pack-upgrader.php
+++ b/wp-admin/includes/class-language-pack-upgrader.php
@@ -274,7 +274,7 @@ class Language_Pack_Upgrader extends WP_Upgrader {
 
 		// Remove upgrade hooks which are not required for translation updates.
 		remove_action( 'upgrader_process_complete', array( 'Language_Pack_Upgrader', 'async_upgrade' ), 20 );
-		remove_action( 'upgrader_process_complete', 'wp_version_check' );
+		remove_action( 'upgrader_process_complete', 'retraceur_version_check' );
 		remove_action( 'upgrader_process_complete', 'wp_update_plugins' );
 		remove_action( 'upgrader_process_complete', 'wp_update_themes' );
 
@@ -292,7 +292,7 @@ class Language_Pack_Upgrader extends WP_Upgrader {
 
 		// Re-add upgrade hooks.
 		add_action( 'upgrader_process_complete', array( 'Language_Pack_Upgrader', 'async_upgrade' ), 20 );
-		add_action( 'upgrader_process_complete', 'wp_version_check', 10, 0 );
+		add_action( 'upgrader_process_complete', 'retraceur_version_check', 10, 0 );
 		add_action( 'upgrader_process_complete', 'wp_update_plugins', 10, 0 );
 		add_action( 'upgrader_process_complete', 'wp_update_themes', 10, 0 );
 

--- a/wp-admin/includes/class-plugin-upgrader.php
+++ b/wp-admin/includes/class-plugin-upgrader.php
@@ -256,17 +256,6 @@ class Plugin_Upgrader extends WP_Upgrader {
 		// Force refresh of plugin update information.
 		wp_clean_plugins_cache( $parsed_args['clear_update_cache'] );
 
-		/*
-		 * Ensure any future auto-update failures trigger a failure email by removing
-		 * the last failure notification from the list when plugins update successfully.
-		 */
-		$past_failure_emails = get_option( 'auto_plugin_theme_update_emails', array() );
-
-		if ( isset( $past_failure_emails[ $plugin ] ) ) {
-			unset( $past_failure_emails[ $plugin ] );
-			update_option( 'auto_plugin_theme_update_emails', $past_failure_emails );
-		}
-
 		return true;
 	}
 
@@ -432,23 +421,6 @@ class Plugin_Upgrader extends WP_Upgrader {
 
 		// Cleanup our hooks, in case something else does an upgrade on this connection.
 		remove_filter( 'upgrader_clear_destination', array( $this, 'delete_old_plugin' ) );
-
-		/*
-		 * Ensure any future auto-update failures trigger a failure email by removing
-		 * the last failure notification from the list when plugins update successfully.
-		 */
-		$past_failure_emails = get_option( 'auto_plugin_theme_update_emails', array() );
-
-		foreach ( $results as $plugin => $result ) {
-			// Maintain last failure notification when plugins failed to update manually.
-			if ( ! $result || is_wp_error( $result ) || ! isset( $past_failure_emails[ $plugin ] ) ) {
-				continue;
-			}
-
-			unset( $past_failure_emails[ $plugin ] );
-		}
-
-		update_option( 'auto_plugin_theme_update_emails', $past_failure_emails );
 
 		return $results;
 	}

--- a/wp-admin/includes/class-theme-upgrader.php
+++ b/wp-admin/includes/class-theme-upgrader.php
@@ -353,17 +353,6 @@ class Theme_Upgrader extends WP_Upgrader {
 
 		wp_clean_themes_cache( $parsed_args['clear_update_cache'] );
 
-		/*
-		 * Ensure any future auto-update failures trigger a failure email by removing
-		 * the last failure notification from the list when themes update successfully.
-		 */
-		$past_failure_emails = get_option( 'auto_plugin_theme_update_emails', array() );
-
-		if ( isset( $past_failure_emails[ $theme ] ) ) {
-			unset( $past_failure_emails[ $theme ] );
-			update_option( 'auto_plugin_theme_update_emails', $past_failure_emails );
-		}
-
 		return true;
 	}
 
@@ -533,23 +522,6 @@ class Theme_Upgrader extends WP_Upgrader {
 		remove_filter( 'upgrader_pre_install', array( $this, 'current_before' ) );
 		remove_filter( 'upgrader_post_install', array( $this, 'current_after' ) );
 		remove_filter( 'upgrader_clear_destination', array( $this, 'delete_old_theme' ) );
-
-		/*
-		 * Ensure any future auto-update failures trigger a failure email by removing
-		 * the last failure notification from the list when themes update successfully.
-		 */
-		$past_failure_emails = get_option( 'auto_plugin_theme_update_emails', array() );
-
-		foreach ( $results as $theme => $result ) {
-			// Maintain last failure notification when themes failed to update manually.
-			if ( ! $result || is_wp_error( $result ) || ! isset( $past_failure_emails[ $theme ] ) ) {
-				continue;
-			}
-
-			unset( $past_failure_emails[ $theme ] );
-		}
-
-		update_option( 'auto_plugin_theme_update_emails', $past_failure_emails );
 
 		return $results;
 	}

--- a/wp-admin/includes/class-wp-automatic-updater.php
+++ b/wp-admin/includes/class-wp-automatic-updater.php
@@ -253,10 +253,6 @@ class WP_Automatic_Updater {
 	protected function send_core_update_notification_email( $item ) {
 		_deprecated_function( __METHOD__, '2.0.0', '', true );
 
-		/**
-		 * @todo Check occurences of this option and adapt code.
-		 */
-		$notified = get_site_option( 'auto_core_update_notified' );
 
 		// Don't notify if we've already notified the same email address of the same version.
 		if ( $notified

--- a/wp-admin/includes/class-wp-automatic-updater.php
+++ b/wp-admin/includes/class-wp-automatic-updater.php
@@ -522,11 +522,6 @@ class WP_Automatic_Updater {
 		_deprecated_function( __METHOD__, '2.0.0', '', true );
 
 		/**
-		 * @todo Check occurences of this option and adapt code.
-		 */
-		get_option( 'auto_plugin_theme_update_emails', array() );
-
-		/**
 		 * Filters the email sent following an automatic background update for plugins and themes.
 		 *
 		 * @since WP 5.5.0

--- a/wp-admin/includes/class-wp-automatic-updater.php
+++ b/wp-admin/includes/class-wp-automatic-updater.php
@@ -58,7 +58,7 @@ class WP_Automatic_Updater {
 		 *
 		 * @param bool $disabled Whether the updater should be disabled.
 		 */
-		return apply_filters( 'automatic_updater_disabled', true );
+		return apply_filters( 'automatic_updater_disabled', $disabled );
 	}
 
 	/**

--- a/wp-admin/includes/class-wp-automatic-updater.php
+++ b/wp-admin/includes/class-wp-automatic-updater.php
@@ -55,7 +55,7 @@ class WP_Automatic_Updater {
 			array( false ),
 			'2.0.0',
 			'',
-			__( 'The WP Auto Updates feature is not used by Retraceur fork.' )
+			__( 'The WP Background Updates feature is not used by Retraceur fork.' )
 		);
 
 		return false;
@@ -234,7 +234,7 @@ class WP_Automatic_Updater {
 			array( $update, $item ),
 			'2.0.0',
 			'',
-			__( 'The WP Auto Updates feature is not used by Retraceur fork.' )
+			__( 'The WP Background Updates feature is not used by Retraceur fork.' )
 		);
 
 		return false;
@@ -293,7 +293,7 @@ class WP_Automatic_Updater {
 			array( $notify, $item ),
 			'2.0.0',
 			'',
-			__( 'The WP Auto Updates feature is not used by Retraceur fork.' )
+			__( 'The WP Background Updates feature is not used by Retraceur fork.' )
 		);
 
 		return false;
@@ -329,7 +329,7 @@ class WP_Automatic_Updater {
 			array( '', $item, '' ),
 			'2.0.0',
 			'',
-			__( 'The WP Auto Updates feature is not used by Retraceur fork.' )
+			__( 'The WP Background Updates feature is not used by Retraceur fork.' )
 		);
 
 		return null;
@@ -343,7 +343,7 @@ class WP_Automatic_Updater {
 	 */
 	public function run() {
 		_deprecated_function( __METHOD__, '2.0.0', '', true );
-		$not_supported = __( 'The WP Auto Updates feature is not used by Retraceur fork.' );
+		$not_supported = __( 'The WP Background Updates feature is not used by Retraceur fork.' );
 
 		/**
 		 * Filters whether to send a debugging email for each automatic background update.
@@ -415,7 +415,7 @@ class WP_Automatic_Updater {
 	protected function send_email( $type, $core_update, $result = null ) {
 		_deprecated_function( __METHOD__, '2.0.0', '', true );
 		$core_update   = new stdClass();
-		$not_supported = __( 'The WP Auto Updates feature is not used by Retraceur fork.' );
+		$not_supported = __( 'The WP Background Updates feature is not used by Retraceur fork.' );
 
 		/**
 		 * Filters whether to send an email following an automatic background core update.
@@ -479,7 +479,7 @@ class WP_Automatic_Updater {
 	 */
 	protected function after_plugin_theme_update( $update_results ) {
 		_deprecated_function( __METHOD__, '2.0.0', '', true );
-		$not_supported = __( 'The WP Auto Updates feature is not used by Retraceur fork.' );
+		$not_supported = __( 'The WP Background Updates feature is not used by Retraceur fork.' );
 
 		/**
 		 * Filters whether to send an email following an automatic background plugin update.
@@ -560,7 +560,7 @@ class WP_Automatic_Updater {
 			array( array(), '', array(), array() ),
 			'2.0.0',
 			'',
-			__( 'The WP Auto Updates feature is not used by Retraceur fork.' )
+			__( 'The WP Background Updates feature is not used by Retraceur fork.' )
 		);
 	}
 
@@ -597,7 +597,7 @@ class WP_Automatic_Updater {
 			array( array(), 0, null ),
 			'2.0.0',
 			'',
-			__( 'The WP Auto Updates feature is not used by Retraceur fork.' )
+			__( 'The WP Background Updates feature is not used by Retraceur fork.' )
 		);
 	}
 

--- a/wp-admin/includes/class-wp-automatic-updater.php
+++ b/wp-admin/includes/class-wp-automatic-updater.php
@@ -389,12 +389,6 @@ class WP_Automatic_Updater {
 	 */
 	protected function after_core_update( $update_result ) {
 		_deprecated_function( __METHOD__, '2.0.0', '', true );
-
-		/**
-		 * @todo Check occurences of this option and adapt code.
-		 */
-		get_site_option( 'auto_core_update_failed' );
-
 		return;
 	}
 

--- a/wp-admin/includes/class-wp-automatic-updater.php
+++ b/wp-admin/includes/class-wp-automatic-updater.php
@@ -29,21 +29,12 @@ class WP_Automatic_Updater {
 	 * Determines whether the entire automatic updater is disabled.
 	 *
 	 * @since WP 3.7.0
+	 * @deprecated 2.0.0 Retraceur fork.
 	 *
 	 * @return bool True if the automatic updater is disabled, false otherwise.
 	 */
 	public function is_disabled() {
-		// Background updates are disabled if you don't want file changes.
-		if ( ! wp_is_file_mod_allowed( 'automatic_updater' ) ) {
-			return true;
-		}
-
-		if ( wp_installing() ) {
-			return true;
-		}
-
-		// More fine grained control can be done through the WP_AUTO_UPDATE_CORE constant and filters.
-		$disabled = defined( 'AUTOMATIC_UPDATER_DISABLED' ) && AUTOMATIC_UPDATER_DISABLED;
+		_deprecated_function( __METHOD__, '2.0.0', '', true );
 
 		/**
 		 * Filters whether to entirely disable background updates.
@@ -55,10 +46,19 @@ class WP_Automatic_Updater {
 		 *
 		 * @since WP 3.7.0
 		 * @since 1.0.0 Retraceur fork disabled auto-updates. It will be back soon.
+		 * @deprecated 2.0.0 Retraceur fork.
 		 *
 		 * @param bool $disabled Whether the updater should be disabled.
 		 */
-		return apply_filters( 'automatic_updater_disabled', $disabled );
+		apply_filters_deprecated(
+			'automatic_updater_disabled',
+			array( false ),
+			'2.0.0',
+			'',
+			__( 'The WP Auto Updates feature is not used by Retraceur fork.' )
+		);
+
+		return false;
 	}
 
 	/**
@@ -185,8 +185,7 @@ class WP_Automatic_Updater {
 	 * Tests to see if we can and should update a specific item.
 	 *
 	 * @since WP 3.7.0
-	 *
-	 * @global wpdb $wpdb Retraceur database abstraction object.
+	 * @deprecated 2.0.0 Retraceur fork.
 	 *
 	 * @param string $type    The type of update being checked: 'core', 'theme',
 	 *                        'plugin', 'translation'.
@@ -196,48 +195,9 @@ class WP_Automatic_Updater {
 	 * @return bool True if the item should be updated, false otherwise.
 	 */
 	public function should_update( $type, $item, $context ) {
-		// Used to see if WP_Filesystem is set up to allow unattended updates.
-		$skin = new Automatic_Upgrader_Skin();
-
-		if ( $this->is_disabled() ) {
-			return false;
-		}
-
-		// Only relax the filesystem checks when the update doesn't include new files.
-		$allow_relaxed_file_ownership = false;
-		if ( 'core' === $type && isset( $item->new_files ) && ! $item->new_files ) {
-			$allow_relaxed_file_ownership = true;
-		}
-
-		// If we can't do an auto core update, we may still be able to email the user.
-		if ( ! $skin->request_filesystem_credentials( false, $context, $allow_relaxed_file_ownership )
-			|| $this->is_vcs_checkout( $context )
-		) {
-			if ( 'core' === $type ) {
-				$this->send_core_update_notification_email( $item );
-			}
-			return false;
-		}
-
-		// Next up, is this an item we can update?
-		if ( 'core' === $type ) {
-			$update = Core_Upgrader::should_update_to_version( $item->current );
-		} elseif ( 'plugin' === $type || 'theme' === $type ) {
-			$update = ! empty( $item->autoupdate );
-
-			if ( ! $update && wp_is_auto_update_enabled_for_type( $type ) ) {
-				// Check if the site admin has enabled auto-updates by default for the specific item.
-				$auto_updates = (array) get_site_option( "auto_update_{$type}s", array() );
-				$update       = in_array( $item->{$type}, $auto_updates, true );
-			}
-		} else {
-			$update = ! empty( $item->autoupdate );
-		}
-
-		// If the `disable_autoupdate` flag is set, override any user-choice, but allow filters.
-		if ( ! empty( $item->disable_autoupdate ) ) {
-			$update = false;
-		}
+		_deprecated_function( __METHOD__, '2.0.0', '', true );
+		$update = false;
+		$item   =  new stdClass();
 
 		/**
 		 * Filters whether to automatically update core, a plugin, a theme, or a language.
@@ -263,56 +223,39 @@ class WP_Automatic_Updater {
 		 *
 		 * @since WP 3.7.0
 		 * @since WP 5.5.0 The `$update` parameter accepts the value of null.
+		 * @deprecated 2.0.0 Retraceur fork.
 		 *
 		 * @param bool|null $update Whether to update. The value of null is internally used
 		 *                          to detect whether nothing has hooked into this filter.
 		 * @param object    $item   The update offer.
 		 */
-		$update = apply_filters( "auto_update_{$type}", $update, $item );
+		apply_filters_deprecated(
+			"auto_update_{$type}",
+			array( $update, $item ),
+			'2.0.0',
+			'',
+			__( 'The WP Auto Updates feature is not used by Retraceur fork.' )
+		);
 
-		if ( ! $update ) {
-			if ( 'core' === $type ) {
-				$this->send_core_update_notification_email( $item );
-			}
-			return false;
-		}
-
-		// If it's a core update, are we actually compatible with its requirements?
-		if ( 'core' === $type ) {
-			global $wpdb;
-
-			$php_compat = version_compare( PHP_VERSION, $item->php_version, '>=' );
-			if ( file_exists( WP_CONTENT_DIR . '/db.php' ) && empty( $wpdb->is_mysql ) ) {
-				$mysql_compat = true;
-			} else {
-				$mysql_compat = version_compare( $wpdb->db_version(), $item->mysql_version, '>=' );
-			}
-
-			if ( ! $php_compat || ! $mysql_compat ) {
-				return false;
-			}
-		}
-
-		// If updating a plugin or theme, ensure the minimum PHP version requirements are satisfied.
-		if ( in_array( $type, array( 'plugin', 'theme' ), true ) ) {
-			if ( ! empty( $item->requires_php ) && version_compare( PHP_VERSION, $item->requires_php, '<' ) ) {
-				return false;
-			}
-		}
-
-		return true;
+		return false;
 	}
 
 	/**
 	 * Notifies an administrator of a core update.
 	 *
 	 * @since WP 3.7.0
+	 * @deprecated 2.0.0 Retraceur fork.
 	 *
 	 * @param object $item The update offer.
 	 * @return bool True if the site administrator is notified of a core update,
 	 *              false otherwise.
 	 */
 	protected function send_core_update_notification_email( $item ) {
+		_deprecated_function( __METHOD__, '2.0.0', '', true );
+
+		/**
+		 * @todo Check occurences of this option and adapt code.
+		 */
 		$notified = get_site_option( 'auto_core_update_notified' );
 
 		// Don't notify if we've already notified the same email address of the same version.
@@ -340,447 +283,103 @@ class WP_Automatic_Updater {
 		 * these notifications.
 		 *
 		 * @since WP 3.7.0
+		 * @deprecated 2.0.0 Retraceur fork.
 		 *
 		 * @param bool   $notify Whether the site administrator is notified.
 		 * @param object $item   The update offer.
 		 */
-		if ( ! apply_filters( 'send_core_update_notification_email', $notify, $item ) ) {
-			return false;
-		}
+		apply_filters_deprecated(
+			'send_core_update_notification_email',
+			array( $notify, $item ),
+			'2.0.0',
+			'',
+			__( 'The WP Auto Updates feature is not used by Retraceur fork.' )
+		);
 
-		$this->send_email( 'manual', $item );
-		return true;
+		return false;
 	}
 
 	/**
 	 * Updates an item, if appropriate.
 	 *
 	 * @since WP 3.7.0
+	 * @deprecated 2.0.0 Retraceur fork.
 	 *
 	 * @param string $type The type of update being checked: 'core', 'theme', 'plugin', 'translation'.
 	 * @param object $item The update offer.
 	 * @return null|WP_Error
 	 */
 	public function update( $type, $item ) {
-		$skin = new Automatic_Upgrader_Skin();
-
-		switch ( $type ) {
-			case 'core':
-				// The Core upgrader doesn't use the Upgrader's skin during the actual main part of the upgrade, instead, firing a filter.
-				add_filter( 'update_feedback', array( $skin, 'feedback' ) );
-				$upgrader = new Core_Upgrader( $skin );
-				$context  = ABSPATH;
-				break;
-			case 'plugin':
-				$upgrader = new Plugin_Upgrader( $skin );
-				$context  = WP_PLUGIN_DIR; // We don't support custom Plugin directories, or updates for WPMU_PLUGIN_DIR.
-				break;
-			case 'theme':
-				$upgrader = new Theme_Upgrader( $skin );
-				$context  = get_theme_root( $item->theme );
-				break;
-			case 'translation':
-				$upgrader = new Language_Pack_Upgrader( $skin );
-				$context  = WP_CONTENT_DIR; // WP_LANG_DIR;
-				break;
-		}
-
-		// Determine whether we can and should perform this update.
-		if ( ! $this->should_update( $type, $item, $context ) ) {
-			return false;
-		}
+		_deprecated_function( __METHOD__, '2.0.0', '', true );
+		$item =  new stdClass();
 
 		/**
 		 * Fires immediately prior to an auto-update.
 		 *
 		 * @since WP 4.4.0
+		 * @deprecated 2.0.0 Retraceur fork.
 		 *
 		 * @param string $type    The type of update being checked: 'core', 'theme', 'plugin', or 'translation'.
 		 * @param object $item    The update offer.
 		 * @param string $context The filesystem context (a path) against which filesystem access and status
 		 *                        should be checked.
 		 */
-		do_action( 'pre_auto_update', $type, $item, $context );
-
-		$upgrader_item = $item;
-		switch ( $type ) {
-			case 'core':
-				/* translators: %s: Retraceur version. */
-				$skin->feedback( __( 'Updating to Retraceur %s' ), $item->version );
-				/* translators: %s: Retraceur version. */
-				$item_name = sprintf( __( 'Retraceur %s' ), $item->version );
-				break;
-			case 'theme':
-				$upgrader_item = $item->theme;
-				$theme         = wp_get_theme( $upgrader_item );
-				$item_name     = $theme->Get( 'Name' );
-				// Add the current version so that it can be reported in the notification email.
-				$item->current_version = $theme->get( 'Version' );
-				if ( empty( $item->current_version ) ) {
-					$item->current_version = false;
-				}
-				/* translators: %s: Theme name. */
-				$skin->feedback( __( 'Updating theme: %s' ), $item_name );
-				break;
-			case 'plugin':
-				$upgrader_item = $item->plugin;
-				$plugin_data   = get_plugin_data( $context . '/' . $upgrader_item );
-				$item_name     = $plugin_data['Name'];
-				// Add the current version so that it can be reported in the notification email.
-				$item->current_version = $plugin_data['Version'];
-				if ( empty( $item->current_version ) ) {
-					$item->current_version = false;
-				}
-				/* translators: %s: Plugin name. */
-				$skin->feedback( __( 'Updating plugin: %s' ), $item_name );
-				break;
-			case 'translation':
-				$language_item_name = $upgrader->get_name_for_update( $item );
-				/* translators: %s: Project name (plugin, theme, or Retraceur). */
-				$item_name = sprintf( __( 'Translations for %s' ), $language_item_name );
-				/* translators: 1: Project name (plugin, theme, or Retraceur), 2: Language. */
-				$skin->feedback( sprintf( __( 'Updating translations for %1$s (%2$s)&#8230;' ), $language_item_name, $item->language ) );
-				break;
-		}
-
-		$allow_relaxed_file_ownership = false;
-		if ( 'core' === $type && isset( $item->new_files ) && ! $item->new_files ) {
-			$allow_relaxed_file_ownership = true;
-		}
-
-		$is_debug = WP_DEBUG && WP_DEBUG_LOG;
-		if ( 'plugin' === $type ) {
-			$was_active = is_plugin_active( $upgrader_item );
-			if ( $is_debug ) {
-				error_log( '    Upgrading plugin ' . var_export( $item->slug, true ) . '...' );
-			}
-		}
-
-		if ( 'theme' === $type && $is_debug ) {
-			error_log( '    Upgrading theme ' . var_export( $item->theme, true ) . '...' );
-		}
-
-		/*
-		 * Enable maintenance mode before upgrading the plugin or theme.
-		 *
-		 * This avoids potential non-fatal errors being detected
-		 * while scraping for a fatal error if some files are still
-		 * being moved.
-		 *
-		 * While these checks are intended only for plugins,
-		 * maintenance mode is enabled for all upgrade types as any
-		 * update could contain an error or warning, which could cause
-		 * the scrape to miss a fatal error in the plugin update.
-		 */
-		if ( 'translation' !== $type ) {
-			$upgrader->maintenance_mode( true );
-		}
-
-		// Boom, this site's about to get a whole new splash of paint!
-		$upgrade_result = $upgrader->upgrade(
-			$upgrader_item,
-			array(
-				'clear_update_cache'           => false,
-				// Always use partial builds if possible for core updates.
-				'pre_check_md5'                => false,
-				// Only available for core updates.
-				'attempt_rollback'             => true,
-				// Allow relaxed file ownership in some scenarios.
-				'allow_relaxed_file_ownership' => $allow_relaxed_file_ownership,
-			)
+		do_action_deprecated(
+			'pre_auto_update',
+			array( '', $item, '' ),
+			'2.0.0',
+			'',
+			__( 'The WP Auto Updates feature is not used by Retraceur fork.' )
 		);
 
-		/*
-		 * After WP_Upgrader::upgrade() completes, maintenance mode is disabled.
-		 *
-		 * Re-enable maintenance mode while attempting to detect fatal errors
-		 * and potentially rolling back.
-		 *
-		 * This avoids errors if the site is visited while fatal errors exist
-		 * or while files are still being moved.
-		 */
-		if ( 'translation' !== $type ) {
-			$upgrader->maintenance_mode( true );
-		}
-
-		// If the filesystem is unavailable, false is returned.
-		if ( false === $upgrade_result ) {
-			$upgrade_result = new WP_Error( 'fs_unavailable', __( 'Could not access filesystem.' ) );
-		}
-
-		if ( 'core' === $type ) {
-			if ( is_wp_error( $upgrade_result )
-				&& ( 'up_to_date' === $upgrade_result->get_error_code()
-					|| 'locked' === $upgrade_result->get_error_code() )
-			) {
-				// Allow visitors to browse the site again.
-				$upgrader->maintenance_mode( false );
-
-				/*
-				 * These aren't actual errors, treat it as a skipped-update instead
-				 * to avoid triggering the post-core update failure routines.
-				 */
-				return false;
-			}
-
-			// Core doesn't output this, so let's append it, so we don't get confused.
-			if ( is_wp_error( $upgrade_result ) ) {
-				$upgrade_result->add( 'installation_failed', __( 'Installation failed.' ) );
-				$skin->error( $upgrade_result );
-			} else {
-				$skin->feedback( __( 'Retraceur updated successfully.' ) );
-			}
-		}
-
-		$is_debug = WP_DEBUG && WP_DEBUG_LOG;
-
-		if ( 'theme' === $type && $is_debug ) {
-			error_log( '    Theme ' . var_export( $item->theme, true ) . ' has been upgraded.' );
-		}
-
-		if ( 'plugin' === $type ) {
-			if ( $is_debug ) {
-				error_log( '    Plugin ' . var_export( $item->slug, true ) . ' has been upgraded.' );
-				if ( is_plugin_inactive( $upgrader_item ) ) {
-					error_log( '    ' . var_export( $upgrader_item, true ) . ' is inactive and will not be checked for fatal errors.' );
-				}
-			}
-
-			if ( $was_active && ! is_wp_error( $upgrade_result ) ) {
-
-				/*
-				 * The usual time limit is five minutes. However, as a loopback request
-				 * is about to be performed, increase the time limit to account for this.
-				 */
-				if ( function_exists( 'set_time_limit' ) ) {
-					set_time_limit( 10 * MINUTE_IN_SECONDS );
-				}
-
-				/*
-				 * Avoids a race condition when there are 2 sequential plugins that have
-				 * fatal errors. It seems a slight delay is required for the loopback to
-				 * use the updated plugin code in the request. This can cause the second
-				 * plugin's fatal error checking to be inaccurate, and may also affect
-				 * subsequent plugin checks.
-				 */
-				sleep( 2 );
-
-				if ( $this->has_fatal_error() ) {
-					$upgrade_result = new WP_Error();
-					$temp_backup    = array(
-						array(
-							'dir'  => 'plugins',
-							'slug' => $item->slug,
-							'src'  => WP_PLUGIN_DIR,
-						),
-					);
-
-					$backup_restored = $upgrader->restore_temp_backup( $temp_backup );
-					if ( is_wp_error( $backup_restored ) ) {
-						$upgrade_result->add(
-							'plugin_update_fatal_error_rollback_failed',
-							sprintf(
-								/* translators: %s: The plugin's slug. */
-								__( "The update for '%s' contained a fatal error. The previously installed version could not be restored." ),
-								$item->slug
-							)
-						);
-
-						$upgrade_result->merge_from( $backup_restored );
-					} else {
-						$upgrade_result->add(
-							'plugin_update_fatal_error_rollback_successful',
-							sprintf(
-								/* translators: %s: The plugin's slug. */
-								__( "The update for '%s' contained a fatal error. The previously installed version has been restored." ),
-								$item->slug
-							)
-						);
-
-						$backup_deleted = $upgrader->delete_temp_backup( $temp_backup );
-						if ( is_wp_error( $backup_deleted ) ) {
-							$upgrade_result->merge_from( $backup_deleted );
-						}
-					}
-
-					/*
-					 * Should emails not be working, log the message(s) so that
-					 * the log file contains context for the fatal error,
-					 * and whether a rollback was performed.
-					 *
-					 * `trigger_error()` is not used as it outputs a stack trace
-					 * to this location rather than to the fatal error, which will
-					 * appear above this entry in the log file.
-					 */
-					if ( $is_debug ) {
-						error_log( '    ' . implode( "\n", $upgrade_result->get_error_messages() ) );
-					}
-				} elseif ( $is_debug ) {
-					error_log( '    The update for ' . var_export( $item->slug, true ) . ' has no fatal errors.' );
-				}
-			}
-		}
-
-		// All processes are complete. Allow visitors to browse the site again.
-		if ( 'translation' !== $type ) {
-			$upgrader->maintenance_mode( false );
-		}
-
-		$this->update_results[ $type ][] = (object) array(
-			'item'     => $item,
-			'result'   => $upgrade_result,
-			'name'     => $item_name,
-			'messages' => $skin->get_upgrade_messages(),
-		);
-
-		return $upgrade_result;
+		return null;
 	}
 
 	/**
 	 * Kicks off the background update process, looping through all pending updates.
 	 *
 	 * @since WP 3.7.0
+	 * @deprecated 2.0.0 Retraceur fork.
 	 */
 	public function run() {
-		if ( $this->is_disabled() ) {
-			return;
-		}
+		_deprecated_function( __METHOD__, '2.0.0', '', true );
+		$not_supported = __( 'The WP Auto Updates feature is not used by Retraceur fork.' );
 
-		if ( ! is_main_network() || ! is_main_site() ) {
-			return;
-		}
-
-		if ( ! WP_Upgrader::create_lock( 'auto_updater' ) ) {
-			return;
-		}
-
-		$is_debug = WP_DEBUG && WP_DEBUG_LOG;
-
-		if ( $is_debug ) {
-			error_log( 'Automatic updates starting...' );
-		}
-
-		// Don't automatically run these things, as we'll handle it ourselves.
-		remove_action( 'upgrader_process_complete', array( 'Language_Pack_Upgrader', 'async_upgrade' ), 20 );
-		remove_action( 'upgrader_process_complete', 'retraceur_version_check' );
-		remove_action( 'upgrader_process_complete', 'wp_update_plugins' );
-		remove_action( 'upgrader_process_complete', 'wp_update_themes' );
-
-		// Next, plugins.
-		wp_update_plugins(); // Check for plugin updates.
-		$plugin_updates = get_site_transient( 'update_plugins' );
-		if ( $plugin_updates && ! empty( $plugin_updates->response ) ) {
-			if ( $is_debug ) {
-				error_log( '  Automatic plugin updates starting...' );
-			}
-
-			foreach ( $plugin_updates->response as $plugin ) {
-				$this->update( 'plugin', $plugin );
-			}
-
-			// Force refresh of plugin update information.
-			wp_clean_plugins_cache();
-
-			if ( $is_debug ) {
-				error_log( '  Automatic plugin updates complete.' );
-			}
-		}
-
-		// Next, those themes we all love.
-		wp_update_themes();  // Check for theme updates.
-		$theme_updates = get_site_transient( 'update_themes' );
-		if ( $theme_updates && ! empty( $theme_updates->response ) ) {
-			if ( $is_debug ) {
-				error_log( '  Automatic theme updates starting...' );
-			}
-
-			foreach ( $theme_updates->response as $theme ) {
-				$this->update( 'theme', (object) $theme );
-			}
-			// Force refresh of theme update information.
-			wp_clean_themes_cache();
-
-			if ( $is_debug ) {
-				error_log( '  Automatic theme updates complete.' );
-			}
-		}
-
-		if ( $is_debug ) {
-			error_log( 'Automatic updates complete.' );
-		}
-
-		// Next, process any core update.
-		retraceur_version_check(); // Check for core updates.
-
-		/*
-		 * Clean up, and check for any pending translations.
-		 * (Core_Upgrader checks for core updates.)
+		/**
+		 * Filters whether to send a debugging email for each automatic background update.
+		 *
+		 * @since WP 3.7.0
+		 * @deprecated 2.0.0 Retraceur fork.
+		 *
+		 * @param bool $development_version By default, emails are sent if the
+		 *                                  install is a development version.
+		 *                                  Return false to avoid the email.
 		 */
-		$theme_stats = array();
-		if ( isset( $this->update_results['theme'] ) ) {
-			foreach ( $this->update_results['theme'] as $upgrade ) {
-				$theme_stats[ $upgrade->item->theme ] = ( true === $upgrade->result );
-			}
-		}
-		wp_update_themes( $theme_stats ); // Check for theme updates.
+		apply_filters_deprecated(
+			'automatic_updates_send_debug_email',
+			array( false ),
+			'2.0.0',
+			'',
+			$not_supported
+		);
 
-		$plugin_stats = array();
-		if ( isset( $this->update_results['plugin'] ) ) {
-			foreach ( $this->update_results['plugin'] as $upgrade ) {
-				$plugin_stats[ $upgrade->item->plugin ] = ( true === $upgrade->result );
-			}
-		}
-		wp_update_plugins( $plugin_stats ); // Check for plugin updates.
+		/**
+		 * Fires after all automatic updates have run.
+		 *
+		 * @since WP 3.8.0
+		 * @deprecated 2.0.0 Retraceur fork.
+		 *
+		 * @param array $update_results The results of all attempted updates.
+		 */
+		do_action_deprecated(
+			'automatic_updates_complete',
+			array( array() ),
+			'2.0.0',
+			'',
+			$not_supported
+		);
 
-		// Finally, process any new translations.
-		$language_updates = wp_get_translation_updates();
-		if ( $language_updates ) {
-			foreach ( $language_updates as $update ) {
-				$this->update( 'translation', $update );
-			}
-
-			// Clear existing caches.
-			wp_clean_update_cache();
-
-			retraceur_version_check();  // Check for core updates.
-			wp_update_themes();  // Check for theme updates.
-			wp_update_plugins(); // Check for plugin updates.
-		}
-
-		// Send debugging email to admin for all development installations.
-		if ( ! empty( $this->update_results ) ) {
-			$development_version = str_contains( retraceur_get_version(), '-' );
-
-			/**
-			 * Filters whether to send a debugging email for each automatic background update.
-			 *
-			 * @since WP 3.7.0
-			 *
-			 * @param bool $development_version By default, emails are sent if the
-			 *                                  install is a development version.
-			 *                                  Return false to avoid the email.
-			 */
-			if ( apply_filters( 'automatic_updates_send_debug_email', $development_version ) ) {
-				$this->send_debug_email();
-			}
-
-			if ( ! empty( $this->update_results['core'] ) ) {
-				$this->after_core_update( $this->update_results['core'][0] );
-			} elseif ( ! empty( $this->update_results['plugin'] ) || ! empty( $this->update_results['theme'] ) ) {
-				$this->after_plugin_theme_update( $this->update_results );
-			}
-
-			/**
-			 * Fires after all automatic updates have run.
-			 *
-			 * @since WP 3.8.0
-			 *
-			 * @param array $update_results The results of all attempted updates.
-			 */
-			do_action( 'automatic_updates_complete', $this->update_results );
-		}
-
-		WP_Upgrader::release_lock( 'auto_updater' );
+		return;
 	}
 
 	/**
@@ -788,140 +387,41 @@ class WP_Automatic_Updater {
 	 * attempting a core update.
 	 *
 	 * @since WP 3.7.0
+	 * @deprecated 2.0.0 Retraceur fork.
 	 *
 	 * @param object $update_result The result of the core update. Includes the update offer and result.
 	 */
 	protected function after_core_update( $update_result ) {
-		$retraceur_version = retraceur_get_version();
+		_deprecated_function( __METHOD__, '2.0.0', '', true );
 
-		$core_update = $update_result->item;
-		$result      = $update_result->result;
-
-		if ( ! is_wp_error( $result ) ) {
-			$this->send_email( 'success', $core_update );
-			return;
-		}
-
-		$error_code = $result->get_error_code();
-
-		/*
-		 * Any of these WP_Error codes are critical failures, as in they occurred after we started to copy core files.
-		 * We should not try to perform a background update again until there is a successful one-click update performed by the user.
+		/**
+		 * @todo Check occurences of this option and adapt code.
 		 */
-		$critical = false;
-		if ( 'disk_full' === $error_code || str_contains( $error_code, '__copy_dir' ) ) {
-			$critical = true;
-		} elseif ( 'rollback_was_required' === $error_code && is_wp_error( $result->get_error_data()->rollback ) ) {
-			// A rollback is only critical if it failed too.
-			$critical        = true;
-			$rollback_result = $result->get_error_data()->rollback;
-		} elseif ( str_contains( $error_code, 'do_rollback' ) ) {
-			$critical = true;
-		}
+		get_site_option( 'auto_core_update_failed' );
 
-		if ( $critical ) {
-			$critical_data = array(
-				'attempted'  => $core_update->current,
-				'current'    => $retraceur_version,
-				'error_code' => $error_code,
-				'error_data' => $result->get_error_data(),
-				'timestamp'  => time(),
-				'critical'   => true,
-			);
-			if ( isset( $rollback_result ) ) {
-				$critical_data['rollback_code'] = $rollback_result->get_error_code();
-				$critical_data['rollback_data'] = $rollback_result->get_error_data();
-			}
-			update_site_option( 'auto_core_update_failed', $critical_data );
-			$this->send_email( 'critical', $core_update, $result );
-			return;
-		}
-
-		/*
-		 * Any other WP_Error code (like download_failed or files_not_writable) occurs before
-		 * we tried to copy over core files. Thus, the failures are early and graceful.
-		 *
-		 * We should avoid trying to perform a background update again for the same version.
-		 * But we can try again if another version is released.
-		 *
-		 * For certain 'transient' failures, like download_failed, we should allow retries.
-		 * In fact, let's schedule a special update for an hour from now. If that one fails,
-		 * then email.
-		 */
-		$send               = true;
-		$transient_failures = array( 'incompatible_archive', 'download_failed', 'insane_distro', 'locked' );
-		if ( in_array( $error_code, $transient_failures, true ) && ! get_site_option( 'auto_core_update_failed' ) ) {
-			wp_schedule_single_event( time() + HOUR_IN_SECONDS, 'wp_maybe_auto_update' );
-			$send = false;
-		}
-
-		$notified = get_site_option( 'auto_core_update_notified' );
-
-		// Don't notify if we've already notified the same email address of the same version of the same notification type.
-		if ( $notified
-			&& 'fail' === $notified['type']
-			&& get_site_option( 'admin_email' ) === $notified['email']
-			&& $notified['version'] === $core_update->current
-		) {
-			$send = false;
-		}
-
-		update_site_option(
-			'auto_core_update_failed',
-			array(
-				'attempted'  => $core_update->current,
-				'current'    => $retraceur_version,
-				'error_code' => $error_code,
-				'error_data' => $result->get_error_data(),
-				'timestamp'  => time(),
-				'retry'      => in_array( $error_code, $transient_failures, true ),
-			)
-		);
-
-		if ( $send ) {
-			$this->send_email( 'fail', $core_update, $result );
-		}
+		return;
 	}
 
 	/**
 	 * Sends an email upon the completion or failure of a background core update.
 	 *
 	 * @since WP 3.7.0
+	 * @deprecated 2.0.0 Retraceur fork.
 	 *
 	 * @param string $type        The type of email to send. Can be one of 'success', 'fail', 'manual', 'critical'.
 	 * @param object $core_update The update offer that was attempted.
 	 * @param mixed  $result      Optional. The result for the core update. Can be WP_Error.
 	 */
 	protected function send_email( $type, $core_update, $result = null ) {
-		update_site_option(
-			'auto_core_update_notified',
-			array(
-				'type'      => $type,
-				'email'     => get_site_option( 'admin_email' ),
-				'version'   => $core_update->current,
-				'timestamp' => time(),
-			)
-		);
-
-		$next_user_core_update = get_preferred_from_update_core();
-
-		// If the update transient is empty, use the update we just performed.
-		if ( ! $next_user_core_update ) {
-			$next_user_core_update = $core_update;
-		}
-
-		if ( 'upgrade' === $next_user_core_update->response
-			&& version_compare( $next_user_core_update->version, $core_update->version, '>' )
-		) {
-			$newer_version_available = true;
-		} else {
-			$newer_version_available = false;
-		}
+		_deprecated_function( __METHOD__, '2.0.0', '', true );
+		$core_update   = new stdClass();
+		$not_supported = __( 'The WP Auto Updates feature is not used by Retraceur fork.' );
 
 		/**
 		 * Filters whether to send an email following an automatic background core update.
 		 *
 		 * @since WP 3.7.0
+		 * @deprecated 2.0.0 Retraceur fork.
 		 *
 		 * @param bool   $send        Whether to send the email. Default true.
 		 * @param string $type        The type of email to send. Can be one of
@@ -929,199 +429,19 @@ class WP_Automatic_Updater {
 		 * @param object $core_update The update offer that was attempted.
 		 * @param mixed  $result      The result for the core update. Can be WP_Error.
 		 */
-		if ( 'manual' !== $type && ! apply_filters( 'auto_core_update_send_email', true, $type, $core_update, $result ) ) {
-			return;
-		}
-
-		$admin_user = get_user_by( 'email', get_site_option( 'admin_email' ) );
-
-		if ( $admin_user ) {
-			$switched_locale = switch_to_user_locale( $admin_user->ID );
-		} else {
-			$switched_locale = switch_to_locale( get_locale() );
-		}
-
-		switch ( $type ) {
-			case 'success': // We updated.
-				/* translators: Site updated notification email subject. 1: Site title, 2: Retraceur version. */
-				$subject = __( '[%1$s] Your site has updated to Retraceur %2$s' );
-				break;
-
-			case 'fail':   // We tried to update but couldn't.
-			case 'manual': // We can't update (and made no attempt).
-				/* translators: Update available notification email subject. 1: Site title, 2: Retraceur version. */
-				$subject = __( '[%1$s] Retraceur %2$s is available. Please update!' );
-				break;
-
-			case 'critical': // We tried to update, started to copy files, then things went wrong.
-				/* translators: Site down notification email subject. 1: Site title. */
-				$subject = __( '[%1$s] URGENT: Your site may be down due to a failed update' );
-				break;
-
-			default:
-				return;
-		}
-
-		// If the auto-update is not to the latest version, say that the current version of WP is available instead.
-		$version = 'success' === $type ? $core_update->current : $next_user_core_update->current;
-		$subject = sprintf( $subject, wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ), $version );
-
-		$body = '';
-
-		switch ( $type ) {
-			case 'success':
-				$body .= sprintf(
-					/* translators: 1: Home URL, 2: Retraceur version. */
-					__( 'Howdy! Your site at %1$s has been updated automatically to Retraceur %2$s.' ),
-					home_url(),
-					$core_update->current
-				);
-				$body .= "\n\n";
-				if ( ! $newer_version_available ) {
-					$body .= __( 'No further action is needed on your part.' ) . ' ';
-				}
-
-				// Can only reference the About screen if their update was successful.
-				list( $about_version ) = explode( '-', $core_update->current, 2 );
-				/* translators: %s: Retraceur version. */
-				$body .= sprintf( __( 'For more on version %s, see the About Retraceur screen:' ), $about_version );
-				$body .= "\n" . admin_url( 'about.php' );
-
-				if ( $newer_version_available ) {
-					/* translators: %s: Retraceur latest version. */
-					$body .= "\n\n" . sprintf( __( 'Retraceur %s is also now available.' ), $next_user_core_update->current ) . ' ';
-					$body .= __( 'Updating is easy and only takes a few moments:' );
-					$body .= "\n" . network_admin_url( 'update-core.php' );
-				}
-
-				break;
-
-			case 'fail':
-			case 'manual':
-				$body .= sprintf(
-					/* translators: 1: Home URL, 2: Retraceur version. */
-					__( 'Please update your site at %1$s to Retraceur %2$s.' ),
-					home_url(),
-					$next_user_core_update->current
-				);
-
-				$body .= "\n\n";
-
-				/*
-				 * Don't show this message if there is a newer version available.
-				 * Potential for confusion, and also not useful for them to know at this point.
-				 */
-				if ( 'fail' === $type && ! $newer_version_available ) {
-					$body .= __( 'An attempt was made, but your site could not be updated automatically.' ) . ' ';
-				}
-
-				$body .= __( 'Updating is easy and only takes a few moments:' );
-				$body .= "\n" . network_admin_url( 'update-core.php' );
-				break;
-
-			case 'critical':
-				if ( $newer_version_available ) {
-					$body .= sprintf(
-						/* translators: 1: Home URL, 2: Retraceur version. */
-						__( 'Your site at %1$s experienced a critical failure while trying to update Retraceur to version %2$s.' ),
-						home_url(),
-						$core_update->current
-					);
-				} else {
-					$body .= sprintf(
-						/* translators: 1: Home URL, 2: Retraceur latest version. */
-						__( 'Your site at %1$s experienced a critical failure while trying to update to the latest version of Retraceur, %2$s.' ),
-						home_url(),
-						$core_update->current
-					);
-				}
-
-				$body .= "\n\n" . __( "This means your site may be offline or broken. Don't panic; this can be fixed." );
-
-				$body .= "\n\n" . __( "Please check out your site now. It's possible that everything is working. If it says you need to update, you should do so:" );
-				$body .= "\n" . network_admin_url( 'update-core.php' );
-				break;
-		}
-
-		$critical_support = 'critical' === $type && ! empty( $core_update->support_email );
-		if ( $critical_support ) {
-			// Support offer if available.
-			$body .= "\n\n" . sprintf(
-				/* translators: %s: Support email address. */
-				__( 'The Retraceur team is willing to help you. Forward this email to %s and the team will work with you to make sure your site is working.' ),
-				$core_update->support_email
-			);
-		}
-
-		// Updates are important!
-		if ( 'success' !== $type || $newer_version_available ) {
-			$body .= "\n\n" . __( 'Keeping your site updated is important for security. It also makes the internet a safer place for you and your readers.' );
-		}
-
-		if ( $critical_support ) {
-			$body .= ' ' . __( "Reach out to Retraceur Core developers to ensure you'll never have this problem again." );
-		}
-
-		// If things are successful and we're now on the latest, mention plugins and themes if any are out of date.
-		if ( 'success' === $type && ! $newer_version_available && ( get_plugin_updates() || get_theme_updates() ) ) {
-			$body .= "\n\n" . __( 'You also have some plugins or themes with updates available. Update them now:' );
-			$body .= "\n" . network_admin_url();
-		}
-
-		$body .= "\n\n" . __( 'The Retraceur Team' ) . "\n";
-
-		if ( 'critical' === $type && is_wp_error( $result ) ) {
-			$body .= "\n***\n\n";
-			/* translators: %s: Retraceur version. */
-			$body .= sprintf( __( 'Your site was running version %s.' ), get_bloginfo( 'version' ) );
-			$body .= ' ' . __( 'Some data that describes the error your site encountered has been put together.' );
-			$body .= ' ' . __( 'Your hosting company, support forum volunteers, or a friendly developer may be able to use this information to help you:' );
-
-			/*
-			 * If we had a rollback and we're still critical, then the rollback failed too.
-			 * Loop through all errors (the main WP_Error, the update result, the rollback result) for code, data, etc.
-			 */
-			if ( 'rollback_was_required' === $result->get_error_code() ) {
-				$errors = array( $result, $result->get_error_data()->update, $result->get_error_data()->rollback );
-			} else {
-				$errors = array( $result );
-			}
-
-			foreach ( $errors as $error ) {
-				if ( ! is_wp_error( $error ) ) {
-					continue;
-				}
-
-				$error_code = $error->get_error_code();
-				/* translators: %s: Error code. */
-				$body .= "\n\n" . sprintf( __( 'Error code: %s' ), $error_code );
-
-				if ( 'rollback_was_required' === $error_code ) {
-					continue;
-				}
-
-				if ( $error->get_error_message() ) {
-					$body .= "\n" . $error->get_error_message();
-				}
-
-				$error_data = $error->get_error_data();
-				if ( $error_data ) {
-					$body .= "\n" . implode( ', ', (array) $error_data );
-				}
-			}
-
-			$body .= "\n";
-		}
-
-		$to      = get_site_option( 'admin_email' );
-		$headers = '';
-
-		$email = compact( 'to', 'subject', 'body', 'headers' );
+		apply_filters_deprecated(
+			'auto_core_update_send_email',
+			array( false, '', $core_update, null ),
+			'2.0.0',
+			'',
+			$not_supported
+		);
 
 		/**
 		 * Filters the email sent following an automatic background core update.
 		 *
 		 * @since WP 3.7.0
+		 * @deprecated 2.0.0 Retraceur fork.
 		 *
 		 * @param array $email {
 		 *     Array of email arguments that will be passed to wp_mail().
@@ -1137,13 +457,15 @@ class WP_Automatic_Updater {
 		 * @param object $core_update The update offer that was attempted.
 		 * @param mixed  $result      The result for the core update. Can be WP_Error.
 		 */
-		$email = apply_filters( 'auto_core_update_email', $email, $type, $core_update, $result );
+		apply_filters_deprecated(
+			'auto_core_update_email',
+			array( array(), '', $core_update, null ),
+			'2.0.0',
+			'',
+			$not_supported
+		);
 
-		wp_mail( $email['to'], wp_specialchars_decode( $email['subject'] ), $email['body'], $email['headers'] );
-
-		if ( $switched_locale ) {
-			restore_previous_locale();
-		}
+		return;
 	}
 
 
@@ -1151,368 +473,74 @@ class WP_Automatic_Updater {
 	 * Checks whether an email should be sent after attempting plugin or theme updates.
 	 *
 	 * @since WP 5.5.0
+	 * @deprecated 2.0.0 Retraceur fork.
 	 *
 	 * @param array $update_results The results of update tasks.
 	 */
 	protected function after_plugin_theme_update( $update_results ) {
-		$successful_updates = array();
-		$failed_updates     = array();
+		_deprecated_function( __METHOD__, '2.0.0', '', true );
+		$not_supported = __( 'The WP Auto Updates feature is not used by Retraceur fork.' );
 
-		if ( ! empty( $update_results['plugin'] ) ) {
-			/**
-			 * Filters whether to send an email following an automatic background plugin update.
-			 *
-			 * @since WP 5.5.0
-			 * @since WP 5.5.1 Added the `$update_results` parameter.
-			 *
-			 * @param bool  $enabled        True if plugin update notifications are enabled, false otherwise.
-			 * @param array $update_results The results of plugins update tasks.
-			 */
-			$notifications_enabled = apply_filters( 'auto_plugin_update_send_email', true, $update_results['plugin'] );
+		/**
+		 * Filters whether to send an email following an automatic background plugin update.
+		 *
+		 * @since WP 5.5.0
+		 * @since WP 5.5.1 Added the `$update_results` parameter.
+		 * @deprecated 2.0.0 Retraceur fork.
+		 *
+		 * @param bool  $enabled        True if plugin update notifications are enabled, false otherwise.
+		 * @param array $update_results The results of plugins update tasks.
+		 */
+		apply_filters_deprecated(
+			'auto_plugin_update_send_email',
+			array( false, array() ),
+			'2.0.0',
+			'',
+			$not_supported
+		);
 
-			if ( $notifications_enabled ) {
-				foreach ( $update_results['plugin'] as $update_result ) {
-					if ( true === $update_result->result ) {
-						$successful_updates['plugin'][] = $update_result;
-					} else {
-						$failed_updates['plugin'][] = $update_result;
-					}
-				}
-			}
-		}
-
-		if ( ! empty( $update_results['theme'] ) ) {
-			/**
-			 * Filters whether to send an email following an automatic background theme update.
-			 *
-			 * @since WP 5.5.0
-			 * @since WP 5.5.1 Added the `$update_results` parameter.
-			 *
-			 * @param bool  $enabled        True if theme update notifications are enabled, false otherwise.
-			 * @param array $update_results The results of theme update tasks.
-			 */
-			$notifications_enabled = apply_filters( 'auto_theme_update_send_email', true, $update_results['theme'] );
-
-			if ( $notifications_enabled ) {
-				foreach ( $update_results['theme'] as $update_result ) {
-					if ( true === $update_result->result ) {
-						$successful_updates['theme'][] = $update_result;
-					} else {
-						$failed_updates['theme'][] = $update_result;
-					}
-				}
-			}
-		}
-
-		if ( empty( $successful_updates ) && empty( $failed_updates ) ) {
-			return;
-		}
-
-		if ( empty( $failed_updates ) ) {
-			$this->send_plugin_theme_email( 'success', $successful_updates, $failed_updates );
-		} elseif ( empty( $successful_updates ) ) {
-			$this->send_plugin_theme_email( 'fail', $successful_updates, $failed_updates );
-		} else {
-			$this->send_plugin_theme_email( 'mixed', $successful_updates, $failed_updates );
-		}
+		/**
+		 * Filters whether to send an email following an automatic background theme update.
+		 *
+		 * @since WP 5.5.0
+		 * @since WP 5.5.1 Added the `$update_results` parameter.
+		 * @deprecated 2.0.0 Retraceur fork.
+		 *
+		 * @param bool  $enabled        True if theme update notifications are enabled, false otherwise.
+		 * @param array $update_results The results of theme update tasks.
+		 */
+		apply_filters_deprecated(
+			'auto_theme_update_send_email',
+			array( false, array() ),
+			'2.0.0',
+			'',
+			$not_supported
+		);
 	}
 
 	/**
 	 * Sends an email upon the completion or failure of a plugin or theme background update.
 	 *
 	 * @since WP 5.5.0
+	 * @deprecated 2.0.0 Retraceur fork.
 	 *
 	 * @param string $type               The type of email to send. Can be one of 'success', 'fail', 'mixed'.
 	 * @param array  $successful_updates A list of updates that succeeded.
 	 * @param array  $failed_updates     A list of updates that failed.
 	 */
 	protected function send_plugin_theme_email( $type, $successful_updates, $failed_updates ) {
-		// No updates were attempted.
-		if ( empty( $successful_updates ) && empty( $failed_updates ) ) {
-			return;
-		}
+		_deprecated_function( __METHOD__, '2.0.0', '', true );
 
-		$unique_failures     = false;
-		$past_failure_emails = get_option( 'auto_plugin_theme_update_emails', array() );
-
-		/*
-		 * When only failures have occurred, an email should only be sent if there are unique failures.
-		 * A failure is considered unique if an email has not been sent for an update attempt failure
-		 * to a plugin or theme with the same new_version.
+		/**
+		 * @todo Check occurences of this option and adapt code.
 		 */
-		if ( 'fail' === $type ) {
-			foreach ( $failed_updates as $update_type => $failures ) {
-				foreach ( $failures as $failed_update ) {
-					if ( ! isset( $past_failure_emails[ $failed_update->item->{$update_type} ] ) ) {
-						$unique_failures = true;
-						continue;
-					}
-
-					// Check that the failure represents a new failure based on the new_version.
-					if ( version_compare( $past_failure_emails[ $failed_update->item->{$update_type} ], $failed_update->item->new_version, '<' ) ) {
-						$unique_failures = true;
-					}
-				}
-			}
-
-			if ( ! $unique_failures ) {
-				return;
-			}
-		}
-
-		$admin_user = get_user_by( 'email', get_site_option( 'admin_email' ) );
-
-		if ( $admin_user ) {
-			$switched_locale = switch_to_user_locale( $admin_user->ID );
-		} else {
-			$switched_locale = switch_to_locale( get_locale() );
-		}
-
-		$body               = array();
-		$successful_plugins = ( ! empty( $successful_updates['plugin'] ) );
-		$successful_themes  = ( ! empty( $successful_updates['theme'] ) );
-		$failed_plugins     = ( ! empty( $failed_updates['plugin'] ) );
-		$failed_themes      = ( ! empty( $failed_updates['theme'] ) );
-
-		switch ( $type ) {
-			case 'success':
-				if ( $successful_plugins && $successful_themes ) {
-					/* translators: %s: Site title. */
-					$subject = __( '[%s] Some plugins and themes have automatically updated' );
-					$body[]  = sprintf(
-						/* translators: %s: Home URL. */
-						__( 'Howdy! Some plugins and themes have automatically updated to their latest versions on your site at %s. No further action is needed on your part.' ),
-						home_url()
-					);
-				} elseif ( $successful_plugins ) {
-					/* translators: %s: Site title. */
-					$subject = __( '[%s] Some plugins were automatically updated' );
-					$body[]  = sprintf(
-						/* translators: %s: Home URL. */
-						__( 'Howdy! Some plugins have automatically updated to their latest versions on your site at %s. No further action is needed on your part.' ),
-						home_url()
-					);
-				} else {
-					/* translators: %s: Site title. */
-					$subject = __( '[%s] Some themes were automatically updated' );
-					$body[]  = sprintf(
-						/* translators: %s: Home URL. */
-						__( 'Howdy! Some themes have automatically updated to their latest versions on your site at %s. No further action is needed on your part.' ),
-						home_url()
-					);
-				}
-
-				break;
-			case 'fail':
-			case 'mixed':
-				if ( $failed_plugins && $failed_themes ) {
-					/* translators: %s: Site title. */
-					$subject = __( '[%s] Some plugins and themes have failed to update' );
-					$body[]  = sprintf(
-						/* translators: %s: Home URL. */
-						__( 'Howdy! Plugins and themes failed to update on your site at %s.' ),
-						home_url()
-					);
-				} elseif ( $failed_plugins ) {
-					/* translators: %s: Site title. */
-					$subject = __( '[%s] Some plugins have failed to update' );
-					$body[]  = sprintf(
-						/* translators: %s: Home URL. */
-						__( 'Howdy! Plugins failed to update on your site at %s.' ),
-						home_url()
-					);
-				} else {
-					/* translators: %s: Site title. */
-					$subject = __( '[%s] Some themes have failed to update' );
-					$body[]  = sprintf(
-						/* translators: %s: Home URL. */
-						__( 'Howdy! Themes failed to update on your site at %s.' ),
-						home_url()
-					);
-				}
-
-				break;
-		}
-
-		if ( in_array( $type, array( 'fail', 'mixed' ), true ) ) {
-			$body[] = "\n";
-			$body[] = __( 'Please check your site now. It’s possible that everything is working. If there are updates available, you should update.' );
-			$body[] = "\n";
-
-			// List failed plugin updates.
-			if ( ! empty( $failed_updates['plugin'] ) ) {
-				$body[] = __( 'The following plugins failed to update. If there was a fatal error in the update, the previously installed version has been restored.' );
-
-				foreach ( $failed_updates['plugin'] as $item ) {
-					$body_message = '';
-					$item_url     = '';
-
-					if ( ! empty( $item->item->url ) ) {
-						$item_url = ' : ' . esc_url( $item->item->url );
-					}
-
-					if ( $item->item->current_version ) {
-						$body_message .= sprintf(
-							/* translators: 1: Plugin name, 2: Current version number, 3: New version number, 4: Plugin URL. */
-							__( '- %1$s (from version %2$s to %3$s)%4$s' ),
-							html_entity_decode( $item->name ),
-							$item->item->current_version,
-							$item->item->new_version,
-							$item_url
-						);
-					} else {
-						$body_message .= sprintf(
-							/* translators: 1: Plugin name, 2: Version number, 3: Plugin URL. */
-							__( '- %1$s version %2$s%3$s' ),
-							html_entity_decode( $item->name ),
-							$item->item->new_version,
-							$item_url
-						);
-					}
-
-					$body[] = $body_message;
-
-					$past_failure_emails[ $item->item->plugin ] = $item->item->new_version;
-				}
-
-				$body[] = "\n";
-			}
-
-			// List failed theme updates.
-			if ( ! empty( $failed_updates['theme'] ) ) {
-				$body[] = __( 'These themes failed to update:' );
-
-				foreach ( $failed_updates['theme'] as $item ) {
-					if ( $item->item->current_version ) {
-						$body[] = sprintf(
-							/* translators: 1: Theme name, 2: Current version number, 3: New version number. */
-							__( '- %1$s (from version %2$s to %3$s)' ),
-							html_entity_decode( $item->name ),
-							$item->item->current_version,
-							$item->item->new_version
-						);
-					} else {
-						$body[] = sprintf(
-							/* translators: 1: Theme name, 2: Version number. */
-							__( '- %1$s version %2$s' ),
-							html_entity_decode( $item->name ),
-							$item->item->new_version
-						);
-					}
-
-					$past_failure_emails[ $item->item->theme ] = $item->item->new_version;
-				}
-
-				$body[] = "\n";
-			}
-		}
-
-		// List successful updates.
-		if ( in_array( $type, array( 'success', 'mixed' ), true ) ) {
-			$body[] = "\n";
-
-			// List successful plugin updates.
-			if ( ! empty( $successful_updates['plugin'] ) ) {
-				$body[] = __( 'These plugins are now up to date:' );
-
-				foreach ( $successful_updates['plugin'] as $item ) {
-					$body_message = '';
-					$item_url     = '';
-
-					if ( ! empty( $item->item->url ) ) {
-						$item_url = ' : ' . esc_url( $item->item->url );
-					}
-
-					if ( $item->item->current_version ) {
-						$body_message .= sprintf(
-							/* translators: 1: Plugin name, 2: Current version number, 3: New version number, 4: Plugin URL. */
-							__( '- %1$s (from version %2$s to %3$s)%4$s' ),
-							html_entity_decode( $item->name ),
-							$item->item->current_version,
-							$item->item->new_version,
-							$item_url
-						);
-					} else {
-						$body_message .= sprintf(
-							/* translators: 1: Plugin name, 2: Version number, 3: Plugin URL. */
-							__( '- %1$s version %2$s%3$s' ),
-							html_entity_decode( $item->name ),
-							$item->item->new_version,
-							$item_url
-						);
-					}
-					$body[] = $body_message;
-
-					unset( $past_failure_emails[ $item->item->plugin ] );
-				}
-
-				$body[] = "\n";
-			}
-
-			// List successful theme updates.
-			if ( ! empty( $successful_updates['theme'] ) ) {
-				$body[] = __( 'These themes are now up to date:' );
-
-				foreach ( $successful_updates['theme'] as $item ) {
-					if ( $item->item->current_version ) {
-						$body[] = sprintf(
-							/* translators: 1: Theme name, 2: Current version number, 3: New version number. */
-							__( '- %1$s (from version %2$s to %3$s)' ),
-							html_entity_decode( $item->name ),
-							$item->item->current_version,
-							$item->item->new_version
-						);
-					} else {
-						$body[] = sprintf(
-							/* translators: 1: Theme name, 2: Version number. */
-							__( '- %1$s version %2$s' ),
-							html_entity_decode( $item->name ),
-							$item->item->new_version
-						);
-					}
-
-					unset( $past_failure_emails[ $item->item->theme ] );
-				}
-
-				$body[] = "\n";
-			}
-		}
-
-		if ( $failed_plugins ) {
-			$body[] = sprintf(
-				/* translators: %s: Plugins screen URL. */
-				__( 'To manage plugins on your site, visit the Plugins page: %s' ),
-				admin_url( 'plugins.php' )
-			);
-			$body[] = "\n";
-		}
-
-		if ( $failed_themes ) {
-			$body[] = sprintf(
-				/* translators: %s: Themes screen URL. */
-				__( 'To manage themes on your site, visit the Themes page: %s' ),
-				admin_url( 'themes.php' )
-			);
-			$body[] = "\n";
-		}
-
-		if ( '' !== get_option( 'blogname' ) ) {
-			$site_title = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
-		} else {
-			$site_title = parse_url( home_url(), PHP_URL_HOST );
-		}
-
-		$body    = implode( "\n", $body );
-		$to      = get_site_option( 'admin_email' );
-		$subject = sprintf( $subject, $site_title );
-		$headers = '';
-
-		$email = compact( 'to', 'subject', 'body', 'headers' );
+		get_option( 'auto_plugin_theme_update_emails', array() );
 
 		/**
 		 * Filters the email sent following an automatic background update for plugins and themes.
 		 *
 		 * @since WP 5.5.0
+		 * @deprecated 2.0.0 Retraceur fork.
 		 *
 		 * @param array  $email {
 		 *     Array of email arguments that will be passed to wp_mail().
@@ -1527,187 +555,30 @@ class WP_Automatic_Updater {
 		 * @param array  $successful_updates A list of updates that succeeded.
 		 * @param array  $failed_updates     A list of updates that failed.
 		 */
-		$email = apply_filters( 'auto_plugin_theme_update_email', $email, $type, $successful_updates, $failed_updates );
-
-		$result = wp_mail( $email['to'], wp_specialchars_decode( $email['subject'] ), $email['body'], $email['headers'] );
-
-		if ( $result ) {
-			update_option( 'auto_plugin_theme_update_emails', $past_failure_emails );
-		}
-
-		if ( $switched_locale ) {
-			restore_previous_locale();
-		}
+		apply_filters_deprecated(
+			'auto_plugin_theme_update_email',
+			array( array(), '', array(), array() ),
+			'2.0.0',
+			'',
+			__( 'The WP Auto Updates feature is not used by Retraceur fork.' )
+		);
 	}
 
 	/**
 	 * Prepares and sends an email of a full log of background update results, useful for debugging and geekery.
 	 *
 	 * @since WP 3.7.0
+	 * @deprecated 2.0.0 Retraceur fork.
 	 */
 	protected function send_debug_email() {
-		$admin_user = get_user_by( 'email', get_site_option( 'admin_email' ) );
-
-		if ( $admin_user ) {
-			$switched_locale = switch_to_user_locale( $admin_user->ID );
-		} else {
-			$switched_locale = switch_to_locale( get_locale() );
-		}
-
-		$body     = array();
-		$failures = 0;
-
-		/* translators: %s: Network home URL. */
-		$body[] = sprintf( __( 'Retraceur site: %s' ), network_home_url( '/' ) );
-
-		// Core.
-		if ( isset( $this->update_results['core'] ) ) {
-			$result = $this->update_results['core'][0];
-
-			if ( $result->result && ! is_wp_error( $result->result ) ) {
-				/* translators: %s: Retraceur version. */
-				$body[] = sprintf( __( 'SUCCESS: Retraceur was successfully updated to %s' ), $result->name );
-			} else {
-				/* translators: %s: Retraceur version. */
-				$body[] = sprintf( __( 'FAILED: Retraceur failed to update to %s' ), $result->name );
-				++$failures;
-			}
-
-			$body[] = '';
-		}
-
-		// Plugins, Themes, Translations.
-		foreach ( array( 'plugin', 'theme', 'translation' ) as $type ) {
-			if ( ! isset( $this->update_results[ $type ] ) ) {
-				continue;
-			}
-
-			$success_items = wp_list_filter( $this->update_results[ $type ], array( 'result' => true ) );
-
-			if ( $success_items ) {
-				$messages = array(
-					'plugin'      => __( 'The following plugins were successfully updated:' ),
-					'theme'       => __( 'The following themes were successfully updated:' ),
-					'translation' => __( 'The following translations were successfully updated:' ),
-				);
-
-				$body[] = $messages[ $type ];
-				foreach ( wp_list_pluck( $success_items, 'name' ) as $name ) {
-					/* translators: %s: Name of plugin / theme / translation. */
-					$body[] = ' * ' . sprintf( __( 'SUCCESS: %s' ), $name );
-				}
-			}
-
-			if ( $success_items !== $this->update_results[ $type ] ) {
-				// Failed updates.
-				$messages = array(
-					'plugin'      => __( 'The following plugins failed to update:' ),
-					'theme'       => __( 'The following themes failed to update:' ),
-					'translation' => __( 'The following translations failed to update:' ),
-				);
-
-				$body[] = $messages[ $type ];
-
-				foreach ( $this->update_results[ $type ] as $item ) {
-					if ( ! $item->result || is_wp_error( $item->result ) ) {
-						/* translators: %s: Name of plugin / theme / translation. */
-						$body[] = ' * ' . sprintf( __( 'FAILED: %s' ), $item->name );
-						++$failures;
-					}
-				}
-			}
-
-			$body[] = '';
-		}
-
-		if ( '' !== get_bloginfo( 'name' ) ) {
-			$site_title = wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES );
-		} else {
-			$site_title = parse_url( home_url(), PHP_URL_HOST );
-		}
-
-		if ( $failures ) {
-			$body[] = trim(
-				__(
-					"BETA TESTING?
-=============
-
-This debugging email is sent when you are using a development version of Retraceur."
-				)
-			);
-			$body[] = '';
-
-			/* translators: Background update failed notification email subject. %s: Site title. */
-			$subject = sprintf( __( '[%s] Background Update Failed' ), $site_title );
-		} else {
-			/* translators: Background update finished notification email subject. %s: Site title. */
-			$subject = sprintf( __( '[%s] Background Update Finished' ), $site_title );
-		}
-
-		$body[] = trim(
-			__(
-				'UPDATE LOG
-=========='
-			)
-		);
-		$body[] = '';
-
-		foreach ( array( 'core', 'plugin', 'theme', 'translation' ) as $type ) {
-			if ( ! isset( $this->update_results[ $type ] ) ) {
-				continue;
-			}
-
-			foreach ( $this->update_results[ $type ] as $update ) {
-				$body[] = $update->name;
-				$body[] = str_repeat( '-', strlen( $update->name ) );
-
-				foreach ( $update->messages as $message ) {
-					$body[] = '  ' . html_entity_decode( str_replace( '&#8230;', '...', $message ) );
-				}
-
-				if ( is_wp_error( $update->result ) ) {
-					$results = array( 'update' => $update->result );
-
-					// If we rolled back, we want to know an error that occurred then too.
-					if ( 'rollback_was_required' === $update->result->get_error_code() ) {
-						$results = (array) $update->result->get_error_data();
-					}
-
-					foreach ( $results as $result_type => $result ) {
-						if ( ! is_wp_error( $result ) ) {
-							continue;
-						}
-
-						if ( 'rollback' === $result_type ) {
-							/* translators: 1: Error code, 2: Error message. */
-							$body[] = '  ' . sprintf( __( 'Rollback Error: [%1$s] %2$s' ), $result->get_error_code(), $result->get_error_message() );
-						} else {
-							/* translators: 1: Error code, 2: Error message. */
-							$body[] = '  ' . sprintf( __( 'Error: [%1$s] %2$s' ), $result->get_error_code(), $result->get_error_message() );
-						}
-
-						if ( $result->get_error_data() ) {
-							$body[] = '         ' . implode( ', ', (array) $result->get_error_data() );
-						}
-					}
-				}
-
-				$body[] = '';
-			}
-		}
-
-		$email = array(
-			'to'      => get_site_option( 'admin_email' ),
-			'subject' => $subject,
-			'body'    => implode( "\n", $body ),
-			'headers' => '',
-		);
+		_deprecated_function( __METHOD__, '2.0.0', '', true );
 
 		/**
 		 * Filters the debug email that can be sent following an automatic
 		 * background core update.
 		 *
 		 * @since WP 3.8.0
+		 * @deprecated 2.0.0 Retraceur fork.
 		 *
 		 * @param array $email {
 		 *     Array of email arguments that will be passed to wp_mail().
@@ -1721,13 +592,13 @@ This debugging email is sent when you are using a development version of Retrace
 		 * @param int   $failures The number of failures encountered while upgrading.
 		 * @param mixed $results  The results of all attempted updates.
 		 */
-		$email = apply_filters( 'automatic_updates_debug_email', $email, $failures, $this->update_results );
-
-		wp_mail( $email['to'], wp_specialchars_decode( $email['subject'] ), $email['body'], $email['headers'] );
-
-		if ( $switched_locale ) {
-			restore_previous_locale();
-		}
+		apply_filters_deprecated(
+			'automatic_updates_debug_email',
+			array( array(), 0, null ),
+			'2.0.0',
+			'',
+			__( 'The WP Auto Updates feature is not used by Retraceur fork.' )
+		);
 	}
 
 	/**
@@ -1736,84 +607,14 @@ This debugging email is sent when you are using a development version of Retrace
 	 * Fatal errors cannot be detected unless maintenance mode is enabled.
 	 *
 	 * @since WP 6.6.0
+	 * @deprecated 2.0.0 Retraceur fork.
 	 *
 	 * @global int $upgrading The Unix timestamp marking when upgrading Retraceur began.
 	 *
 	 * @return bool Whether a fatal error was detected.
 	 */
 	protected function has_fatal_error() {
-		global $upgrading;
-
-		$maintenance_file = ABSPATH . '.maintenance';
-		if ( ! file_exists( $maintenance_file ) ) {
-			return false;
-		}
-
-		require $maintenance_file;
-		if ( ! is_int( $upgrading ) ) {
-			return false;
-		}
-
-		$scrape_key   = md5( $upgrading );
-		$scrape_nonce = (string) $upgrading;
-		$transient    = 'scrape_key_' . $scrape_key;
-		set_transient( $transient, $scrape_nonce, 30 );
-
-		$cookies       = wp_unslash( $_COOKIE );
-		$scrape_params = array(
-			'wp_scrape_key'   => $scrape_key,
-			'wp_scrape_nonce' => $scrape_nonce,
-		);
-		$headers       = array(
-			'Cache-Control' => 'no-cache',
-		);
-
-		/** This filter is documented in wp-includes/class-wp-http-streams.php */
-		$sslverify = apply_filters( 'https_local_ssl_verify', false );
-
-		// Include Basic auth in the loopback request.
-		if ( isset( $_SERVER['PHP_AUTH_USER'] ) && isset( $_SERVER['PHP_AUTH_PW'] ) ) {
-			$headers['Authorization'] = 'Basic ' . base64_encode( wp_unslash( $_SERVER['PHP_AUTH_USER'] ) . ':' . wp_unslash( $_SERVER['PHP_AUTH_PW'] ) );
-		}
-
-		// Time to wait for loopback request to finish.
-		$timeout = 50; // 50 seconds.
-
-		$is_debug = WP_DEBUG && WP_DEBUG_LOG;
-		if ( $is_debug ) {
-			error_log( '    Scraping home page...' );
-		}
-
-		$needle_start = "###### wp_scraping_result_start:$scrape_key ######";
-		$needle_end   = "###### wp_scraping_result_end:$scrape_key ######";
-		$url          = add_query_arg( $scrape_params, home_url( '/' ) );
-		$response     = wp_remote_get( $url, compact( 'cookies', 'headers', 'timeout', 'sslverify' ) );
-
-		if ( is_wp_error( $response ) ) {
-			if ( $is_debug ) {
-				error_log( 'Loopback request failed: ' . $response->get_error_message() );
-			}
-			return true;
-		}
-
-		// If this outputs `true` in the log, it means there were no fatal errors detected.
-		if ( $is_debug ) {
-			error_log( var_export( substr( $response['body'], strpos( $response['body'], '###### wp_scraping_result_start:' ) ), true ) );
-		}
-
-		$body                   = wp_remote_retrieve_body( $response );
-		$scrape_result_position = strpos( $body, $needle_start );
-		$result                 = null;
-
-		if ( false !== $scrape_result_position ) {
-			$error_output = substr( $body, $scrape_result_position + strlen( $needle_start ) );
-			$error_output = substr( $error_output, 0, strpos( $error_output, $needle_end ) );
-			$result       = json_decode( trim( $error_output ), true );
-		}
-
-		delete_transient( $transient );
-
-		// Only fatal errors will result in a 'type' key.
-		return isset( $result['type'] );
+		_deprecated_function( __METHOD__, '2.0.0', '', true );
+		return false;
 	}
 }

--- a/wp-admin/includes/class-wp-automatic-updater.php
+++ b/wp-admin/includes/class-wp-automatic-updater.php
@@ -662,7 +662,7 @@ class WP_Automatic_Updater {
 
 		// Don't automatically run these things, as we'll handle it ourselves.
 		remove_action( 'upgrader_process_complete', array( 'Language_Pack_Upgrader', 'async_upgrade' ), 20 );
-		remove_action( 'upgrader_process_complete', 'wp_version_check' );
+		remove_action( 'upgrader_process_complete', 'retraceur_version_check' );
 		remove_action( 'upgrader_process_complete', 'wp_update_plugins' );
 		remove_action( 'upgrader_process_complete', 'wp_update_themes' );
 
@@ -710,12 +710,7 @@ class WP_Automatic_Updater {
 		}
 
 		// Next, process any core update.
-		wp_version_check(); // Check for core updates.
-		$core_update = find_core_auto_update();
-
-		if ( $core_update ) {
-			$this->update( 'core', $core_update );
-		}
+		retraceur_version_check(); // Check for core updates.
 
 		/*
 		 * Clean up, and check for any pending translations.
@@ -747,7 +742,7 @@ class WP_Automatic_Updater {
 			// Clear existing caches.
 			wp_clean_update_cache();
 
-			wp_version_check();  // Check for core updates.
+			retraceur_version_check();  // Check for core updates.
 			wp_update_themes();  // Check for theme updates.
 			wp_update_plugins(); // Check for plugin updates.
 		}

--- a/wp-admin/includes/class-wp-debug-data.php
+++ b/wp-admin/includes/class-wp-debug-data.php
@@ -18,8 +18,16 @@ class WP_Debug_Data {
 	 */
 	public static function check_for_updates() {
 		retraceur_version_check();
-		wp_update_plugins();
-		wp_update_themes();
+
+		/**
+		 * @todo Restore when Retraceur adpated its API to handle it.
+		 */
+		// wp_update_plugins();
+
+		/**
+		 * @todo Restore when Retraceur adpated its API to handle it.
+		 */
+		// wp_update_themes();
 	}
 
 	/**

--- a/wp-admin/includes/class-wp-debug-data.php
+++ b/wp-admin/includes/class-wp-debug-data.php
@@ -17,7 +17,7 @@ class WP_Debug_Data {
 	 * @since WP 5.2.0
 	 */
 	public static function check_for_updates() {
-		wp_version_check();
+		retraceur_version_check();
 		wp_update_plugins();
 		wp_update_themes();
 	}
@@ -154,14 +154,14 @@ class WP_Debug_Data {
 		$blog_public            = get_option( 'blog_public' );
 		$environment_type       = wp_get_environment_type();
 		$core_version           = retraceur_get_version();
-		$core_updates           = get_core_updates();
+		$core_updates           = retraceur_get_updates();
 		$core_update_needed     = '';
 
 		if ( is_array( $core_updates ) ) {
 			foreach ( $core_updates as $core => $update ) {
-				if ( 'upgrade' === $update->response ) {
+				if ( true === $update['stable'] ) {
 					/* translators: %s: Latest version number. */
-					$core_update_needed = ' ' . sprintf( __( '(Latest version: %s)' ), $update->version );
+					$core_update_needed = ' ' . sprintf( __( '(Latest version: %s)' ), $update['version'] );
 				} else {
 					$core_update_needed = '';
 				}

--- a/wp-admin/includes/class-wp-site-health-auto-updates.php
+++ b/wp-admin/includes/class-wp-site-health-auto-updates.php
@@ -30,16 +30,11 @@ class WP_Site_Health_Auto_Updates {
 	 */
 	public function run_tests() {
 		$tests = array(
-			//$this->test_constants( 'WP_AUTO_UPDATE_CORE', array( true, 'beta', 'rc', 'development', 'branch-development', 'minor' ) ),
 			$this->test_wp_version_check_attached(),
-			//$this->test_filters_automatic_updater_disabled(),
-			//$this->test_wp_automatic_updates_disabled(),
-			//$this->test_if_failed_update(),
+			$this->test_filters_automatic_updater_disabled(),
 			$this->test_vcs_abspath(),
 			$this->test_check_wp_filesystem_method(),
 			$this->test_all_files_writable(),
-			//$this->test_accepts_dev_updates(),
-			//$this->test_accepts_minor_updates(),
 		);
 
 		$tests = array_filter( $tests );
@@ -64,6 +59,7 @@ class WP_Site_Health_Auto_Updates {
 	 *
 	 * @since WP 5.2.0
 	 * @since WP 5.5.1 The `$value` parameter can accept an array.
+	 * @deprecated 2.0.0 Retraceur fork.
 	 *
 	 * @param string $constant         The name of the constant to check.
 	 * @param bool|string|array $value The value that the constant should be, if set,
@@ -72,20 +68,7 @@ class WP_Site_Health_Auto_Updates {
 	 *                    or null if the test passed.
 	 */
 	public function test_constants( $constant, $value ) {
-		$acceptable_values = (array) $value;
-
-		if ( defined( $constant ) && ! in_array( constant( $constant ), $acceptable_values, true ) ) {
-			return array(
-				'description' => sprintf(
-					/* translators: 1: Name of the constant used. 2: Value of the constant used. */
-					__( 'The %1$s constant is defined as %2$s' ),
-					"<code>$constant</code>",
-					'<code>' . esc_html( var_export( constant( $constant ), true ) ) . '</code>'
-				),
-				'severity'    => 'fail',
-			);
-		}
-
+		_deprecated_function( __METHOD__, '2.0.0', '', true );
 		return null;
 	}
 
@@ -119,17 +102,17 @@ class WP_Site_Health_Auto_Updates {
 	 *
 	 * @since WP 5.2.0
 	 *
-	 * @return array|null The test results if the {@see 'automatic_updater_disabled'} filter is set,
+	 * @return array|null The test results if the {@see 'retraceur_is_updater_enabled'} filter is set,
 	 *                    or null if the test passed.
 	 */
 	public function test_filters_automatic_updater_disabled() {
 		/** This filter is documented in wp-admin/includes/class-wp-automatic-updater.php */
-		if ( apply_filters( 'automatic_updater_disabled', false ) ) {
+		if ( ! apply_filters( 'retraceur_is_updater_enabled', true ) ) {
 			return array(
 				'description' => sprintf(
 					/* translators: %s: Name of the filter used. */
-					__( 'The %s filter is enabled.' ),
-					'<code>automatic_updater_disabled</code>'
+					__( 'The %s filter is disabled.' ),
+					'<code>retraceur_is_updater_enabled</code>'
 				),
 				'severity'    => 'fail',
 			);
@@ -142,70 +125,26 @@ class WP_Site_Health_Auto_Updates {
 	 * Checks if automatic updates are disabled.
 	 *
 	 * @since WP 5.3.0
+	 * @deprecated 2.0.0 Retraceur fork.
 	 *
 	 * @return array|false The test results if auto-updates are disabled, false otherwise.
 	 */
 	public function test_wp_automatic_updates_disabled() {
-		if ( ! class_exists( 'WP_Automatic_Updater' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/class-wp-automatic-updater.php';
-		}
-
-		$auto_updates = new WP_Automatic_Updater();
-
-		if ( ! $auto_updates->is_disabled() ) {
-			return false;
-		}
-
-		return array(
-			'description' => __( 'All automatic updates are disabled.' ),
-			'severity'    => 'fail',
-		);
+		_deprecated_function( __METHOD__, '2.0.0', '', true );
+		return false;
 	}
 
 	/**
 	 * Checks if automatic updates have tried to run, but failed, previously.
 	 *
 	 * @since WP 5.2.0
+	 * @deprecated 2.0.0 Retraceur fork.
 	 *
 	 * @return array|false The test results if auto-updates previously failed, false otherwise.
 	 */
 	public function test_if_failed_update() {
-		$failed = get_site_option( 'auto_core_update_failed' );
-
-		if ( ! $failed ) {
-			return false;
-		}
-
-		if ( ! empty( $failed['critical'] ) ) {
-			$description  = __( 'A previous automatic background update ended with a critical failure, so updates are now disabled.' );
-			$description .= ' ' . __( 'You would have received an email because of this.' );
-			$description .= ' ' . __( "When you've been able to update using the \"Update now\" button on Dashboard > Updates, this error will be cleared for future update attempts." );
-			$description .= ' ' . sprintf(
-				/* translators: %s: Code of error shown. */
-				__( 'The error code was %s.' ),
-				'<code>' . $failed['error_code'] . '</code>'
-			);
-			return array(
-				'description' => $description,
-				'severity'    => 'warning',
-			);
-		}
-
-		$description = __( 'A previous automatic background update could not occur.' );
-		if ( empty( $failed['retry'] ) ) {
-			$description .= ' ' . __( 'You would have received an email because of this.' );
-		}
-
-		$description .= ' ' . __( 'Another attempt will be made with the next release.' );
-		$description .= ' ' . sprintf(
-			/* translators: %s: Code of error shown. */
-			__( 'The error code was %s.' ),
-			'<code>' . $failed['error_code'] . '</code>'
-		);
-		return array(
-			'description' => $description,
-			'severity'    => 'warning',
-		);
+		_deprecated_function( __METHOD__, '2.0.0', '', true );
+		return false;
 	}
 
 	/**
@@ -408,63 +347,27 @@ class WP_Site_Health_Auto_Updates {
 	 * Checks if the install is using a development branch and can use nightly packages.
 	 *
 	 * @since WP 5.2.0
+	 * @deprecated 1.0.0 Retraceur fork.
 	 *
 	 * @return array|false|null The test results if development updates are blocked.
 	 *                          False if it isn't a development version. Null if the test passed.
 	 */
 	public function test_accepts_dev_updates() {
-		require ABSPATH . WPINC . '/version.php'; // $retraceur_version; // x.y.z
-		// Only for dev versions.
-		if ( ! str_contains( $retraceur_version, '-' ) ) {
-			return false;
-		}
-
-		if ( defined( 'WP_AUTO_UPDATE_CORE' ) && ( 'minor' === WP_AUTO_UPDATE_CORE || false === WP_AUTO_UPDATE_CORE ) ) {
-			return array(
-				'description' => sprintf(
-					/* translators: %s: Name of the constant used. */
-					__( 'Retraceur development updates are blocked by the %s constant.' ),
-					'<code>WP_AUTO_UPDATE_CORE</code>'
-				),
-				'severity'    => 'fail',
-			);
-		}
-
-		return null;
+		_deprecated_function( __METHOD__, '2.0.0', '', true );
+		return false;
 	}
 
 	/**
 	 * Checks if the site supports automatic minor updates.
 	 *
 	 * @since WP 5.2.0
+	 * @deprecated 1.0.0 Retraceur fork.
 	 *
 	 * @return array|null The test results if minor updates are blocked,
 	 *                    or null if the test passed.
 	 */
 	public function test_accepts_minor_updates() {
-		if ( defined( 'WP_AUTO_UPDATE_CORE' ) && false === WP_AUTO_UPDATE_CORE ) {
-			return array(
-				'description' => sprintf(
-					/* translators: %s: Name of the constant used. */
-					__( 'Retraceur security and maintenance releases are blocked by %s.' ),
-					"<code>define( 'WP_AUTO_UPDATE_CORE', false );</code>"
-				),
-				'severity'    => 'fail',
-			);
-		}
-
-		/** This filter is documented in wp-admin/includes/class-core-upgrader.php */
-		if ( ! apply_filters( 'allow_minor_auto_core_updates', true ) ) {
-			return array(
-				'description' => sprintf(
-					/* translators: %s: Name of the filter used. */
-					__( 'Retraceur security and maintenance releases are blocked by the %s filter.' ),
-					'<code>allow_minor_auto_core_updates</code>'
-				),
-				'severity'    => 'fail',
-			);
-		}
-
+		_deprecated_function( __METHOD__, '2.0.0', '', true );
 		return null;
 	}
 }

--- a/wp-admin/includes/class-wp-site-health-auto-updates.php
+++ b/wp-admin/includes/class-wp-site-health-auto-updates.php
@@ -347,7 +347,7 @@ class WP_Site_Health_Auto_Updates {
 	 * Checks if the install is using a development branch and can use nightly packages.
 	 *
 	 * @since WP 5.2.0
-	 * @deprecated 1.0.0 Retraceur fork.
+	 * @deprecated 2.0.0 Retraceur fork.
 	 *
 	 * @return array|false|null The test results if development updates are blocked.
 	 *                          False if it isn't a development version. Null if the test passed.
@@ -361,7 +361,7 @@ class WP_Site_Health_Auto_Updates {
 	 * Checks if the site supports automatic minor updates.
 	 *
 	 * @since WP 5.2.0
-	 * @deprecated 1.0.0 Retraceur fork.
+	 * @deprecated 2.0.0 Retraceur fork.
 	 *
 	 * @return array|null The test results if minor updates are blocked,
 	 *                    or null if the test passed.

--- a/wp-admin/includes/class-wp-site-health-auto-updates.php
+++ b/wp-admin/includes/class-wp-site-health-auto-updates.php
@@ -30,16 +30,16 @@ class WP_Site_Health_Auto_Updates {
 	 */
 	public function run_tests() {
 		$tests = array(
-			$this->test_constants( 'WP_AUTO_UPDATE_CORE', array( true, 'beta', 'rc', 'development', 'branch-development', 'minor' ) ),
+			//$this->test_constants( 'WP_AUTO_UPDATE_CORE', array( true, 'beta', 'rc', 'development', 'branch-development', 'minor' ) ),
 			$this->test_wp_version_check_attached(),
-			$this->test_filters_automatic_updater_disabled(),
-			$this->test_wp_automatic_updates_disabled(),
-			$this->test_if_failed_update(),
+			//$this->test_filters_automatic_updater_disabled(),
+			//$this->test_wp_automatic_updates_disabled(),
+			//$this->test_if_failed_update(),
 			$this->test_vcs_abspath(),
 			$this->test_check_wp_filesystem_method(),
 			$this->test_all_files_writable(),
-			$this->test_accepts_dev_updates(),
-			$this->test_accepts_minor_updates(),
+			//$this->test_accepts_dev_updates(),
+			//$this->test_accepts_minor_updates(),
 		);
 
 		$tests = array_filter( $tests );
@@ -94,18 +94,18 @@ class WP_Site_Health_Auto_Updates {
 	 *
 	 * @since WP 5.2.0
 	 *
-	 * @return array|null The test results if wp_version_check() is disabled,
+	 * @return array|null The test results if `retraceur_version_check()` is disabled,
 	 *                    or null if the test passed.
 	 */
 	public function test_wp_version_check_attached() {
 		if ( ( ! is_multisite() || is_main_site() && is_network_admin() )
-			&& ! has_filter( 'wp_version_check', 'wp_version_check' )
+			&& ! has_filter( 'retraceur_version_check', 'retraceur_version_check' )
 		) {
 			return array(
 				'description' => sprintf(
 					/* translators: %s: Name of the filter used. */
 					__( 'A plugin has prevented updates by disabling %s.' ),
-					'<code>wp_version_check()</code>'
+					'<code>retraceur_version_check()</code>'
 				),
 				'severity'    => 'fail',
 			);
@@ -425,18 +425,6 @@ class WP_Site_Health_Auto_Updates {
 					/* translators: %s: Name of the constant used. */
 					__( 'Retraceur development updates are blocked by the %s constant.' ),
 					'<code>WP_AUTO_UPDATE_CORE</code>'
-				),
-				'severity'    => 'fail',
-			);
-		}
-
-		/** This filter is documented in wp-admin/includes/class-core-upgrader.php */
-		if ( ! apply_filters( 'allow_dev_auto_core_updates', $retraceur_version ) ) {
-			return array(
-				'description' => sprintf(
-					/* translators: %s: Name of the filter used. */
-					__( 'Retraceur development updates are blocked by the %s filter.' ),
-					'<code>allow_dev_auto_core_updates</code>'
 				),
 				'severity'    => 'fail',
 			);

--- a/wp-admin/includes/class-wp-site-health.php
+++ b/wp-admin/includes/class-wp-site-health.php
@@ -1278,7 +1278,7 @@ class WP_Site_Health {
 	 * Tests if the site can communicate with WP (org site).
 	 *
 	 * @since WP 5.2.0
-	 * @since 1.0.0
+	 * @deprecated 1.0.0 Retraceur fork.
 	 *
 	 * @return array The test results.
 	 */
@@ -1600,11 +1600,23 @@ class WP_Site_Health {
 	 * for whatever reason.
 	 *
 	 * @since 5.2.0
-	 * @since 2.0.0 Retraceur fork
+	 * @deprecated 2.0.0 Retraceur fork.
 	 *
 	 * @return array The test results.
 	 */
 	public function get_test_background_updates() {
+		_deprecated_function( __METHOD__, '2.0.0', '', true );
+		return array();
+	}
+
+	/**
+	 * Tests if Retraceur can run automated coeur updates.
+	 *
+	 * @since 2.0.0 Retraceur fork
+	 *
+	 * @return array The test results.
+	 */
+	public function get_test_coeur_updates() {
 		$result = array(
 			'label'       => __( 'Coeur updates are working' ),
 			'status'      => 'good',
@@ -1617,7 +1629,7 @@ class WP_Site_Health {
 				__( 'Retraceur Coeur update checks help you be aware when a security update is released for the version you are currently using.' )
 			),
 			'actions'     => '',
-			'test'        => 'background_updates',
+			'test'        => 'coeur_updates',
 		);
 
 		if ( ! class_exists( 'WP_Site_Health_Auto_Updates' ) ) {
@@ -2569,9 +2581,9 @@ class WP_Site_Health {
 					'label' => __( 'Scheduled events' ),
 					'test'  => 'scheduled_events',
 				),
-				'background_updates'           => array(
+				'coeur_updates'                => array(
 					'label' => __( 'Retraceur Coeur updates' ),
-					'test'  => 'background_updates',
+					'test'  => 'coeur_updates',
 				),
 				'http_requests'                => array(
 					'label' => __( 'HTTP Requests' ),

--- a/wp-admin/includes/class-wp-site-health.php
+++ b/wp-admin/includes/class-wp-site-health.php
@@ -223,9 +223,9 @@ class WP_Site_Health {
 	}
 
 	/**
-	 * Tests whether `wp_version_check` is blocked.
+	 * Tests whether `retraceur_version_check()` is blocked.
 	 *
-	 * It's possible to block updates with the `wp_version_check` filter, but this can't be checked
+	 * It's possible to block updates with the `retraceur_version_check` filter, but this can't be checked
 	 * during an Ajax call, as the filter is never introduced then.
 	 *
 	 * This filter overrides a standard page request if it's made by an admin through the Ajax call
@@ -238,7 +238,7 @@ class WP_Site_Health {
 			return;
 		}
 
-		echo ( has_filter( 'wp_version_check', 'wp_version_check' ) ? 'yes' : 'no' );
+		echo ( has_filter( 'retraceur_version_check', 'retraceur_version_check' ) ? 'yes' : 'no' );
 
 		die();
 	}
@@ -285,7 +285,7 @@ class WP_Site_Health {
 		}
 
 		$core_current_version = retraceur_get_version();
-		$core_updates         = get_core_updates();
+		$core_updates         = retraceur_get_updates();
 
 		if ( ! is_array( $core_updates ) ) {
 			$result['status'] = 'recommended';
@@ -308,9 +308,9 @@ class WP_Site_Health {
 			);
 		} else {
 			foreach ( $core_updates as $core => $update ) {
-				if ( 'upgrade' === $update->response ) {
+				if ( true === $update['stable'] ) {
 					$current_version = explode( '.', $core_current_version );
-					$new_version     = explode( '.', $update->version );
+					$new_version     = explode( '.', $update['version'] );
 
 					$current_major = $current_version[0] . '.' . $current_version[1];
 					$new_major     = $new_version[0] . '.' . $new_version[1];
@@ -318,7 +318,7 @@ class WP_Site_Health {
 					$result['label'] = sprintf(
 						/* translators: %s: The latest version of Retraceur available. */
 						__( 'Retraceur update available (%s)' ),
-						$update->version
+						$update['version']
 					);
 
 					$result['actions'] = sprintf(
@@ -1593,6 +1593,86 @@ class WP_Site_Health {
 	}
 
 	/**
+	 * Tests if Retraceur can run automated background updates.
+	 *
+	 * Background updates in WordPress are primarily used for minor releases and security updates.
+	 * It's important to either have these working, or be aware that they are intentionally disabled
+	 * for whatever reason.
+	 *
+	 * @since 5.2.0
+	 * @since 2.0.0 Retraceur fork
+	 *
+	 * @return array The test results.
+	 */
+	public function get_test_background_updates() {
+		$result = array(
+			'label'       => __( 'Background updates are working' ),
+			'status'      => 'good',
+			'badge'       => array(
+				'label' => __( 'Security' ),
+				'color' => 'blue',
+			),
+			'description' => sprintf(
+				'<p>%s</p>',
+				__( 'Retraceur update checks help you be aware when a security update is released for the version you are currently using.' )
+			),
+			'actions'     => '',
+			'test'        => 'background_updates',
+		);
+
+		if ( ! class_exists( 'WP_Site_Health_Auto_Updates' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-site-health-auto-updates.php';
+		}
+
+		/*
+		 * Run the auto-update tests in a separate class,
+		 * as there are many considerations to be made.
+		 */
+		$automatic_updates = new WP_Site_Health_Auto_Updates();
+		$tests             = $automatic_updates->run_tests();
+
+		$output = '<ul>';
+
+		foreach ( $tests as $test ) {
+			/* translators: Hidden accessibility text. */
+			$severity_string = __( 'Passed' );
+
+			if ( 'fail' === $test->severity ) {
+				$result['label'] = __( 'Retraceur updates are not working as expected' );
+
+				$result['status'] = 'critical';
+
+				/* translators: Hidden accessibility text. */
+				$severity_string = __( 'Error' );
+			}
+
+			if ( 'warning' === $test->severity && 'good' === $result['status'] ) {
+				$result['label'] = __( 'Retraceur updates may not be working properly' );
+
+				$result['status'] = 'recommended';
+
+				/* translators: Hidden accessibility text. */
+				$severity_string = __( 'Warning' );
+			}
+
+			$output .= sprintf(
+				'<li><span class="dashicons %s"><span class="screen-reader-text">%s</span></span> %s</li>',
+				esc_attr( $test->severity ),
+				$severity_string,
+				$test->description
+			);
+		}
+
+		$output .= '</ul>';
+
+		if ( 'good' !== $result['status'] ) {
+			$result['description'] .= $output;
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Tests available disk space for updates.
 	 *
 	 * @since WP 6.3.0
@@ -2489,6 +2569,10 @@ class WP_Site_Health {
 					'label' => __( 'Scheduled events' ),
 					'test'  => 'scheduled_events',
 				),
+				'background_updates'           => array(
+					'label' => __( 'Retraceur updates' ),
+					'test'  => 'background_updates',
+				),
 				'http_requests'                => array(
 					'label' => __( 'HTTP Requests' ),
 					'test'  => 'http_requests',
@@ -2505,10 +2589,6 @@ class WP_Site_Health {
 				'file_uploads'                 => array(
 					'label' => __( 'File uploads' ),
 					'test'  => 'file_uploads',
-				),
-				'plugin_theme_auto_updates'    => array(
-					'label' => __( 'Plugin and theme auto-updates' ),
-					'test'  => 'plugin_theme_auto_updates',
 				),
 				'update_temp_backup_writable'  => array(
 					'label' => __( 'Plugin and theme temporary backup directory access' ),

--- a/wp-admin/includes/class-wp-site-health.php
+++ b/wp-admin/includes/class-wp-site-health.php
@@ -1606,7 +1606,7 @@ class WP_Site_Health {
 	 */
 	public function get_test_background_updates() {
 		$result = array(
-			'label'       => __( 'Background updates are working' ),
+			'label'       => __( 'Coeur updates are working' ),
 			'status'      => 'good',
 			'badge'       => array(
 				'label' => __( 'Security' ),
@@ -1614,7 +1614,7 @@ class WP_Site_Health {
 			),
 			'description' => sprintf(
 				'<p>%s</p>',
-				__( 'Retraceur update checks help you be aware when a security update is released for the version you are currently using.' )
+				__( 'Retraceur Coeur update checks help you be aware when a security update is released for the version you are currently using.' )
 			),
 			'actions'     => '',
 			'test'        => 'background_updates',
@@ -1638,7 +1638,7 @@ class WP_Site_Health {
 			$severity_string = __( 'Passed' );
 
 			if ( 'fail' === $test->severity ) {
-				$result['label'] = __( 'Retraceur updates are not working as expected' );
+				$result['label'] = __( 'Retraceur Coeur updates are not working as expected' );
 
 				$result['status'] = 'critical';
 
@@ -1647,7 +1647,7 @@ class WP_Site_Health {
 			}
 
 			if ( 'warning' === $test->severity && 'good' === $result['status'] ) {
-				$result['label'] = __( 'Retraceur updates may not be working properly' );
+				$result['label'] = __( 'Retraceur Coeur updates may not be working properly' );
 
 				$result['status'] = 'recommended';
 
@@ -2570,7 +2570,7 @@ class WP_Site_Health {
 					'test'  => 'scheduled_events',
 				),
 				'background_updates'           => array(
-					'label' => __( 'Retraceur updates' ),
+					'label' => __( 'Retraceur Coeur updates' ),
 					'test'  => 'background_updates',
 				),
 				'http_requests'                => array(

--- a/wp-admin/includes/deprecated.php
+++ b/wp-admin/includes/deprecated.php
@@ -3621,3 +3621,201 @@ function wp_make_plugin_file_tree( $plugin_editable_files ) {
 function wp_print_plugin_file_tree( $tree, $label = '', $level = 2, $size = 1, $index = 1 ) {
 	_deprecated_function( __FUNCTION__, '1.0.0', '', true );
 }
+
+/**
+ * Lists available core updates.
+ *
+ * @since WP 2.7.0
+ * @deprecated 2.0.0 Retraceur fork.
+ *
+ * @global string $wp_local_package Locale code of the package.
+ * @global wpdb   $wpdb             Retraceur database abstraction object.
+ *
+ * @param object $update
+ */
+function list_core_update( $update ) {
+	_deprecated_function( __FUNCTION__, '2.0.0', '', true );
+}
+
+/**
+ * Display Retraceur auto-updates settings.
+ *
+ * @since WP 5.6.0
+ * @deprecated 2.0.0 Retraceur fork.
+ */
+function core_auto_updates_settings() {
+	_deprecated_function( __FUNCTION__, '2.0.0', '', true );
+
+	$not_supported = __( 'The WP Auto Updates feature is not used by Retraceur fork.' );
+
+	/** This filter is documented in wp-admin/includes/class-core-upgrader.php */
+	apply_filters_deprecated(
+		'allow_dev_auto_core_updates',
+		array( false ),
+		'2.0.0',
+		'',
+		$not_supported
+	);
+
+	/** This filter is documented in wp-admin/includes/class-core-upgrader.php */
+	apply_filters_deprecated(
+		'allow_minor_auto_core_updates',
+		array( false ),
+		'2.0.0',
+		'',
+		$not_supported
+	);
+
+	/** This filter is documented in wp-admin/includes/class-core-upgrader.php */
+	apply_filters_deprecated(
+		'allow_major_auto_core_updates',
+		array( false ),
+		'2.0.0',
+		'',
+		$not_supported
+	);
+
+	/**
+	 * Fires after the major core auto-update settings.
+	 *
+	 * @since WP 5.6.0
+	 * @deprecated 2.0.0 Retraceur fork.
+	 *
+	 * @param array $auto_update_settings {
+	 *     Array of core auto-update settings.
+	 *
+	 *     @type bool $dev   Whether to enable automatic updates for development versions.
+	 *     @type bool $minor Whether to enable minor automatic core updates.
+	 *     @type bool $major Whether to enable major automatic core updates.
+	 * }
+	 */
+	do_action_deprecated(
+		'after_core_auto_updates_settings',
+		array( array() ),
+		'2.0.0',
+		'',
+		$not_supported
+	);
+}
+
+/**
+ * Dismiss a core update.
+ *
+ * @since WP 2.7.0
+ * @deprecated 2.0.0 Retraceur fork.
+ */
+function do_dismiss_core_update() {
+	_deprecated_function( __FUNCTION__, '2.0.0', '', true );
+	exit;
+}
+
+/**
+ * Undismiss a core update.
+ *
+ * @since WP 2.7.0
+ * @deprecated 2.0.0 Retraceur fork.
+ */
+function do_undismiss_core_update() {
+	_deprecated_function( __FUNCTION__, '2.0.0', '', true );
+	exit;
+}
+
+/**
+ * Preloads old Requests classes and interfaces.
+ *
+ * This function preloads the old Requests code into memory before the
+ * upgrade process deletes the files. Why? Requests code is loaded into
+ * memory via an autoloader, meaning when a class or interface is needed
+ * If a request is in process, Requests could attempt to access code. If
+ * the file is not there, a fatal error could occur. If the file was
+ * replaced, the new code is not compatible with the old, resulting in
+ * a fatal error. Preloading ensures the code is in memory before the
+ * code is updated.
+ *
+ * @since WP 6.2.0
+ * @deprecated 2.0.0 Retraceur fork.
+ *
+ * @global string[]           $_old_requests_files Requests files to be preloaded.
+ * @global WP_Filesystem_Base $wp_filesystem       WP filesystem subclass.
+ * @global string             $wp_version          The WP version string.
+ * @global string             $retraceur_version   The Retraceur version string.
+ *
+ * @param string $to Path to old Retraceur installation.
+ */
+function _preload_old_requests_classes_and_interfaces( $to ) {
+	_deprecated_function( __FUNCTION__, '2.0.0', '', true );
+}
+
+/**
+ * Gets available core updates.
+ *
+ * @since WP 2.7.0
+ * @deprecated 2.0.0 Retraceur fork.
+ *
+ * @param array $options Set $options['dismissed'] to true to show dismissed upgrades too,
+ *                       set $options['available'] to false to skip not-dismissed updates.
+ * @return array|false Array of the update objects on success, false on failure.
+ */
+function get_core_updates( $options = array() ) {
+	_deprecated_function( __FUNCTION__, '2.0.0', '', true );
+	return array();
+}
+
+/**
+ * Gets the best available (and enabled) Auto-Update for Retraceur core.
+ *
+ * If there's 1.2.3 and 1.3 on offer, it'll choose 1.3 if the installation allows it, else, 1.2.3.
+ *
+ * @since WP 3.7.0
+ * @deprecated 2.0.0 Retraceur fork.
+ *
+ * @return object|false The core update offering on success, false on failure.
+ */
+function find_core_auto_update() {
+	_deprecated_function( __FUNCTION__, '2.0.0', '', true );
+	return false;
+}
+
+/**
+ * Dismisses core update.
+ *
+ * @since WP 2.7.0
+ * @deprecated 2.0.0 Retraceur fork.
+ *
+ * @param object $update
+ * @return bool
+ */
+function dismiss_core_update( $update ) {
+	_deprecated_function( __FUNCTION__, '2.0.0', '', true );
+	return false;
+}
+
+/**
+ * Undismisses core update.
+ *
+ * @since WP 2.7.0
+ * @deprecated 2.0.0 Retraceur fork.
+ *
+ * @param string $version
+ * @param string $locale
+ * @return bool
+ */
+function undismiss_core_update( $version, $locale ) {
+	_deprecated_function( __FUNCTION__, '2.0.0', '', true );
+	return false;
+}
+
+/**
+ * Finds the available update for Retraceur core.
+ *
+ * @since WP 2.7.0
+ * @deprecated 2.0.0 Retraceur fork.
+ *
+ * @param string $version Version string to find the update for.
+ * @param string $locale  Locale to find the update for.
+ * @return object|false The core update offering on success, false on failure.
+ */
+function find_core_update( $version, $locale ) {
+	_deprecated_function( __FUNCTION__, '2.0.0', '', true );
+	return false;
+}

--- a/wp-admin/includes/deprecated.php
+++ b/wp-admin/includes/deprecated.php
@@ -3819,3 +3819,16 @@ function find_core_update( $version, $locale ) {
 	_deprecated_function( __FUNCTION__, '2.0.0', '', true );
 	return false;
 }
+
+/**
+ * Displays maintenance nag HTML message.
+ *
+ * @since WP 2.7.0
+ * @deprecated 2.0.0 Retraceur fork.
+ *
+ * @return void|false
+ */
+function maintenance_nag() {
+	_deprecated_function( __FUNCTION__, '2.0.0', '', true );
+	return false;
+}

--- a/wp-admin/includes/deprecated.php
+++ b/wp-admin/includes/deprecated.php
@@ -3646,7 +3646,7 @@ function list_core_update( $update ) {
 function core_auto_updates_settings() {
 	_deprecated_function( __FUNCTION__, '2.0.0', '', true );
 
-	$not_supported = __( 'The WP Auto Updates feature is not used by Retraceur fork.' );
+	$not_supported = __( 'The WP Background Updates feature is not used by Retraceur fork.' );
 
 	/** This filter is documented in wp-admin/includes/class-core-upgrader.php */
 	apply_filters_deprecated(

--- a/wp-admin/includes/schema.php
+++ b/wp-admin/includes/schema.php
@@ -390,11 +390,6 @@ function populate_options( array $options = array() ) {
 		// 5.5.0
 		'auto_plugin_theme_update_emails' => array(),
 
-		// 5.6.0
-		'auto_update_core_dev'            => 'enabled',
-		'auto_update_core_minor'          => 'enabled',
-		'auto_update_core_major'          => 'enabled',
-
 		// 5.8.0
 		'wp_force_deactivated_plugins'    => array(),
 
@@ -458,6 +453,9 @@ function populate_options( array $options = array() ) {
 
 	// Delete obsolete magpie stuff.
 	$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name REGEXP '^rss_[0-9a-f]{32}(_ts)?$'" );
+
+	// Delete no more used autoupdate stuff.
+	$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'auto_update_core_%'" );
 
 	// Clear expired transients.
 	delete_expired_transients( true );

--- a/wp-admin/includes/schema.php
+++ b/wp-admin/includes/schema.php
@@ -387,9 +387,6 @@ function populate_options( array $options = array() ) {
 		// 5.3.0
 		'admin_email_lifespan'            => ( time() + 6 * MONTH_IN_SECONDS ),
 
-		// 5.5.0
-		'auto_plugin_theme_update_emails' => array(),
-
 		// 5.8.0
 		'wp_force_deactivated_plugins'    => array(),
 
@@ -414,7 +411,6 @@ function populate_options( array $options = array() ) {
 	$fat_options = array(
 		'recently_edited',
 		'uninstall_plugins',
-		'auto_plugin_theme_update_emails',
 	);
 
 	$keys             = "'" . implode( "', '", array_keys( $options ) ) . "'";

--- a/wp-admin/includes/update-core.php
+++ b/wp-admin/includes/update-core.php
@@ -707,10 +707,5 @@ function update_core( $from, $to ) {
 	 */
 	do_action( '_core_updated_successfully', $wp_version, $retraceur_version );
 
-	// Clear the option that blocks auto-updates after failures, now that we've been successful.
-	if ( function_exists( 'delete_site_option' ) ) {
-		delete_site_option( 'auto_core_update_failed' );
-	}
-
 	return $retraceur_version;
 }

--- a/wp-admin/includes/update-core.php
+++ b/wp-admin/includes/update-core.php
@@ -589,18 +589,6 @@ function update_core( $from, $to ) {
 	$wp_filesystem->delete( $maintenance_file );
 
 	/*
-	 * 3.5 -> 3.5+ - an empty twentytwelve directory was created upon upgrade to 3.5 for some users,
-	 * preventing installation of Twenty Twelve.
-	 */
-	if ( '3.5' === $old_wp_version ) {
-		if ( is_dir( WP_CONTENT_DIR . '/themes/twentytwelve' )
-			&& ! file_exists( WP_CONTENT_DIR . '/themes/twentytwelve/style.css' )
-		) {
-			$wp_filesystem->delete( $wp_filesystem->wp_themes_dir() . 'twentytwelve/' );
-		}
-	}
-
-	/*
 	 * Copy new bundled plugins & themes.
 	 * This gives us the ability to install new plugins & themes bundled with
 	 * future versions of Retraceur whilst avoiding the re-install upon upgrade issue.

--- a/wp-admin/includes/update-core.php
+++ b/wp-admin/includes/update-core.php
@@ -104,86 +104,13 @@ $_old_files = array(
  * All other files/directories should not have a key.
  *
  * @since WP 6.2.0
+ * @todo deprecate: Retraceur fork was introduced during 6.7 development cycle.
  *
  * @global string[] $_old_requests_files
  * @var string[]
  * @name $_old_requests_files
  */
 global $_old_requests_files;
-
-$_old_requests_files = array(
-	// Interfaces.
-	'Requests_Auth'                              => 'wp-includes/Requests/Auth.php',
-	'Requests_Hooker'                            => 'wp-includes/Requests/Hooker.php',
-	'Requests_Proxy'                             => 'wp-includes/Requests/Proxy.php',
-	'Requests_Transport'                         => 'wp-includes/Requests/Transport.php',
-
-	// Classes.
-	'Requests_Auth_Basic'                        => 'wp-includes/Requests/Auth/Basic.php',
-	'Requests_Cookie_Jar'                        => 'wp-includes/Requests/Cookie/Jar.php',
-	'Requests_Exception_HTTP'                    => 'wp-includes/Requests/Exception/HTTP.php',
-	'Requests_Exception_Transport'               => 'wp-includes/Requests/Exception/Transport.php',
-	'Requests_Exception_HTTP_304'                => 'wp-includes/Requests/Exception/HTTP/304.php',
-	'Requests_Exception_HTTP_305'                => 'wp-includes/Requests/Exception/HTTP/305.php',
-	'Requests_Exception_HTTP_306'                => 'wp-includes/Requests/Exception/HTTP/306.php',
-	'Requests_Exception_HTTP_400'                => 'wp-includes/Requests/Exception/HTTP/400.php',
-	'Requests_Exception_HTTP_401'                => 'wp-includes/Requests/Exception/HTTP/401.php',
-	'Requests_Exception_HTTP_402'                => 'wp-includes/Requests/Exception/HTTP/402.php',
-	'Requests_Exception_HTTP_403'                => 'wp-includes/Requests/Exception/HTTP/403.php',
-	'Requests_Exception_HTTP_404'                => 'wp-includes/Requests/Exception/HTTP/404.php',
-	'Requests_Exception_HTTP_405'                => 'wp-includes/Requests/Exception/HTTP/405.php',
-	'Requests_Exception_HTTP_406'                => 'wp-includes/Requests/Exception/HTTP/406.php',
-	'Requests_Exception_HTTP_407'                => 'wp-includes/Requests/Exception/HTTP/407.php',
-	'Requests_Exception_HTTP_408'                => 'wp-includes/Requests/Exception/HTTP/408.php',
-	'Requests_Exception_HTTP_409'                => 'wp-includes/Requests/Exception/HTTP/409.php',
-	'Requests_Exception_HTTP_410'                => 'wp-includes/Requests/Exception/HTTP/410.php',
-	'Requests_Exception_HTTP_411'                => 'wp-includes/Requests/Exception/HTTP/411.php',
-	'Requests_Exception_HTTP_412'                => 'wp-includes/Requests/Exception/HTTP/412.php',
-	'Requests_Exception_HTTP_413'                => 'wp-includes/Requests/Exception/HTTP/413.php',
-	'Requests_Exception_HTTP_414'                => 'wp-includes/Requests/Exception/HTTP/414.php',
-	'Requests_Exception_HTTP_415'                => 'wp-includes/Requests/Exception/HTTP/415.php',
-	'Requests_Exception_HTTP_416'                => 'wp-includes/Requests/Exception/HTTP/416.php',
-	'Requests_Exception_HTTP_417'                => 'wp-includes/Requests/Exception/HTTP/417.php',
-	'Requests_Exception_HTTP_418'                => 'wp-includes/Requests/Exception/HTTP/418.php',
-	'Requests_Exception_HTTP_428'                => 'wp-includes/Requests/Exception/HTTP/428.php',
-	'Requests_Exception_HTTP_429'                => 'wp-includes/Requests/Exception/HTTP/429.php',
-	'Requests_Exception_HTTP_431'                => 'wp-includes/Requests/Exception/HTTP/431.php',
-	'Requests_Exception_HTTP_500'                => 'wp-includes/Requests/Exception/HTTP/500.php',
-	'Requests_Exception_HTTP_501'                => 'wp-includes/Requests/Exception/HTTP/501.php',
-	'Requests_Exception_HTTP_502'                => 'wp-includes/Requests/Exception/HTTP/502.php',
-	'Requests_Exception_HTTP_503'                => 'wp-includes/Requests/Exception/HTTP/503.php',
-	'Requests_Exception_HTTP_504'                => 'wp-includes/Requests/Exception/HTTP/504.php',
-	'Requests_Exception_HTTP_505'                => 'wp-includes/Requests/Exception/HTTP/505.php',
-	'Requests_Exception_HTTP_511'                => 'wp-includes/Requests/Exception/HTTP/511.php',
-	'Requests_Exception_HTTP_Unknown'            => 'wp-includes/Requests/Exception/HTTP/Unknown.php',
-	'Requests_Exception_Transport_cURL'          => 'wp-includes/Requests/Exception/Transport/cURL.php',
-	'Requests_Proxy_HTTP'                        => 'wp-includes/Requests/Proxy/HTTP.php',
-	'Requests_Response_Headers'                  => 'wp-includes/Requests/Response/Headers.php',
-	'Requests_Transport_cURL'                    => 'wp-includes/Requests/Transport/cURL.php',
-	'Requests_Transport_fsockopen'               => 'wp-includes/Requests/Transport/fsockopen.php',
-	'Requests_Utility_CaseInsensitiveDictionary' => 'wp-includes/Requests/Utility/CaseInsensitiveDictionary.php',
-	'Requests_Utility_FilteredIterator'          => 'wp-includes/Requests/Utility/FilteredIterator.php',
-	'Requests_Cookie'                            => 'wp-includes/Requests/Cookie.php',
-	'Requests_Exception'                         => 'wp-includes/Requests/Exception.php',
-	'Requests_Hooks'                             => 'wp-includes/Requests/Hooks.php',
-	'Requests_IDNAEncoder'                       => 'wp-includes/Requests/IDNAEncoder.php',
-	'Requests_IPv6'                              => 'wp-includes/Requests/IPv6.php',
-	'Requests_IRI'                               => 'wp-includes/Requests/IRI.php',
-	'Requests_Response'                          => 'wp-includes/Requests/Response.php',
-	'Requests_SSL'                               => 'wp-includes/Requests/SSL.php',
-	'Requests_Session'                           => 'wp-includes/Requests/Session.php',
-
-	// Directories.
-	'wp-includes/Requests/Auth/',
-	'wp-includes/Requests/Cookie/',
-	'wp-includes/Requests/Exception/HTTP/',
-	'wp-includes/Requests/Exception/Transport/',
-	'wp-includes/Requests/Exception/',
-	'wp-includes/Requests/Proxy/',
-	'wp-includes/Requests/Response/',
-	'wp-includes/Requests/Transport/',
-	'wp-includes/Requests/Utility/',
-);
 
 /**
  * Stores new files in wp-content to copy
@@ -209,22 +136,7 @@ $_old_requests_files = array(
 global $_new_bundled_files;
 
 $_new_bundled_files = array(
-	'plugins/akismet/'          => '2.0',
-	'themes/twentyten/'         => '3.0',
-	'themes/twentyeleven/'      => '3.2',
-	'themes/twentytwelve/'      => '3.5',
-	'themes/twentythirteen/'    => '3.6',
-	'themes/twentyfourteen/'    => '3.8',
-	'themes/twentyfifteen/'     => '4.1',
-	'themes/twentysixteen/'     => '4.4',
-	'themes/twentyseventeen/'   => '4.7',
-	'themes/twentynineteen/'    => '5.0',
-	'themes/twentytwenty/'      => '5.3',
-	'themes/twentytwentyone/'   => '5.6',
-	'themes/twentytwentytwo/'   => '5.9',
-	'themes/twentytwentythree/' => '6.1',
-	'themes/twentytwentyfour/'  => '6.4',
-	'themes/twentytwentyfive/'  => '6.7',
+	'themes/point/' => '1.0.0',
 );
 
 /**
@@ -281,7 +193,7 @@ $_new_bundled_files = array(
  * @return string|WP_Error New Retraceur version on success, WP_Error on failure.
  */
 function update_core( $from, $to ) {
-	global $wp_filesystem, $_old_files, $_old_requests_files, $_new_bundled_files, $wpdb;
+	global $wp_filesystem, $_old_files, $_new_bundled_files, $wpdb;
 
 	/*
  	 * Give core update script an additional 300 seconds (5 minutes)
@@ -290,14 +202,6 @@ function update_core( $from, $to ) {
 	if ( function_exists( 'set_time_limit' ) ) {
 		set_time_limit( 300 );
 	}
-
-	/*
-	 * Merge the old Requests files and directories into the `$_old_files`.
-	 * Then preload these Requests files first, before the files are deleted
-	 * and replaced to ensure the code is in memory if needed.
-	 */
-	$_old_files = array_merge( $_old_files, array_values( $_old_requests_files ) );
-	_preload_old_requests_classes_and_interfaces( $to );
 
 	/**
 	 * Filters feedback messages displayed during the core update process.
@@ -322,7 +226,7 @@ function update_core( $from, $to ) {
 	$distro = '';
 	$root   = '/retraceur/';
 
-	if ( $wp_filesystem->exists( $from . $root . 'readme.html' ) && $wp_filesystem->exists( $from . $root . 'wp-includes/version.php' ) ) {
+	if ( $wp_filesystem->exists( $from . $root . 'README.md' ) && $wp_filesystem->exists( $from . $root . 'wp-includes/version.php' ) ) {
 		$distro = $root;
 	}
 
@@ -837,6 +741,7 @@ function update_core( $from, $to ) {
  * code is updated.
  *
  * @since WP 6.2.0
+ * @todo deprecate Retraceur fork started from WP 6.7. Not needed.
  *
  * @global string[]           $_old_requests_files Requests files to be preloaded.
  * @global WP_Filesystem_Base $wp_filesystem       WP filesystem subclass.

--- a/wp-admin/includes/update-core.php
+++ b/wp-admin/includes/update-core.php
@@ -104,7 +104,7 @@ $_old_files = array(
  * All other files/directories should not have a key.
  *
  * @since WP 6.2.0
- * @todo deprecate: Retraceur fork was introduced during 6.7 development cycle.
+ * @deprecated 2.0.0 Retraceur fork was introduced during 6.7 development cycle.
  *
  * @global string[] $_old_requests_files
  * @var string[]
@@ -165,12 +165,12 @@ $_new_bundled_files = array(
  *   5. Delete new Retraceur directory path.
  *   6. Delete .maintenance file.
  *   7. Remove old files.
- *   8. Delete 'update_core' option.
+ *   8. Delete 'update_coeur' option.
  *
  * There are several areas of failure. For instance if PHP times out before step
  * 6, then you will not be able to access any portion of your site. Also, since
  * the upgrade will not continue where it left off, you will not be able to
- * automatically remove old files and remove the 'update_core' option. This
+ * automatically remove old files and remove the 'update_coeur' option. This
  * isn't that bad.
  *
  * If the copy of the new Retraceur over the old fails, then the worse is that
@@ -184,7 +184,6 @@ $_new_bundled_files = array(
  *
  * @global WP_Filesystem_Base $wp_filesystem          WP filesystem subclass.
  * @global string[]           $_old_files
- * @global string[]           $_old_requests_files
  * @global string[]           $_new_bundled_files
  * @global wpdb               $wpdb                   WP database abstraction object.
  *
@@ -705,9 +704,9 @@ function update_core( $from, $to ) {
 
 	// Force refresh of update information.
 	if ( function_exists( 'delete_site_transient' ) ) {
-		delete_site_transient( 'update_core' );
+		delete_site_transient( 'update_coeur' );
 	} else {
-		delete_option( 'update_core' );
+		delete_option( 'update_coeur' );
 	}
 
 	/**
@@ -726,63 +725,4 @@ function update_core( $from, $to ) {
 	}
 
 	return $retraceur_version;
-}
-
-/**
- * Preloads old Requests classes and interfaces.
- *
- * This function preloads the old Requests code into memory before the
- * upgrade process deletes the files. Why? Requests code is loaded into
- * memory via an autoloader, meaning when a class or interface is needed
- * If a request is in process, Requests could attempt to access code. If
- * the file is not there, a fatal error could occur. If the file was
- * replaced, the new code is not compatible with the old, resulting in
- * a fatal error. Preloading ensures the code is in memory before the
- * code is updated.
- *
- * @since WP 6.2.0
- * @todo deprecate Retraceur fork started from WP 6.7. Not needed.
- *
- * @global string[]           $_old_requests_files Requests files to be preloaded.
- * @global WP_Filesystem_Base $wp_filesystem       WP filesystem subclass.
- * @global string             $wp_version          The WP version string.
- * @global string             $retraceur_version   The Retraceur version string.
- *
- * @param string $to Path to old Retraceur installation.
- */
-function _preload_old_requests_classes_and_interfaces( $to ) {
-	global $_old_requests_files, $wp_filesystem, $wp_version, $retraceur_version;
-
-	/*
-	 * Requests was introduced in WP 4.6.
-	 *
-	 * Skip preloading if the website was previously using
-	 * an earlier version of Retraceur.
-	 */
-	if ( version_compare( $wp_version, '4.6', '<' ) ) {
-		return;
-	}
-
-	if ( ! defined( 'REQUESTS_SILENCE_PSR0_DEPRECATIONS' ) ) {
-		define( 'REQUESTS_SILENCE_PSR0_DEPRECATIONS', true );
-	}
-
-	foreach ( $_old_requests_files as $name => $file ) {
-		// Skip files that aren't interfaces or classes.
-		if ( is_int( $name ) ) {
-			continue;
-		}
-
-		// Skip if it's already loaded.
-		if ( class_exists( $name ) || interface_exists( $name ) ) {
-			continue;
-		}
-
-		// Skip if the file is missing.
-		if ( ! $wp_filesystem->is_file( $to . $file ) ) {
-			continue;
-		}
-
-		require_once $to . $file;
-	}
 }

--- a/wp-admin/includes/update.php
+++ b/wp-admin/includes/update.php
@@ -971,17 +971,13 @@ function wp_recovery_mode_nag() {
  * Checks whether auto-updates are enabled.
  *
  * @since WP 5.5.0
+ * @since 2.0.0 Retraceur fork excluded "background' updates.
  *
  * @param string $type The type of update being checked: Either 'theme' or 'plugin'.
- * @return bool True if auto-updates are enabled for `$type`, false otherwise.
+ * @return bool True if updates are enabled for `$type`, false otherwise.
  */
 function wp_is_auto_update_enabled_for_type( $type ) {
-	if ( ! class_exists( 'WP_Automatic_Updater' ) ) {
-		require_once ABSPATH . 'wp-admin/includes/class-wp-automatic-updater.php';
-	}
-
-	$updater = new WP_Automatic_Updater();
-	$enabled = ! $updater->is_disabled();
+	$enabled = retraceur_is_updater_enabled();
 
 	switch ( $type ) {
 		case 'plugin':

--- a/wp-admin/includes/update.php
+++ b/wp-admin/includes/update.php
@@ -63,10 +63,6 @@ function retraceur_get_updates( $options = array() ) {
 	$result  = array();
 
 	foreach ( $updates as $update ) {
-		if ( true !== $update['stable'] ) {
-			continue;
-		}
-
 		if ( current( $updates ) === count( $updates ) - 1 ) {
 			$update['latest'] = true;
 		}
@@ -273,7 +269,28 @@ function undismiss_core_update( $version, $locale ) {
 /**
  * Finds the available update for Retraceur core.
  *
+ * @since 2.0.0 Retraceur fork.
+ *
+ * @param string $version Version string to find the update for.
+ * @param string $locale  Locale to find the update for.
+ * @return array|false The core update offering on success, false on failure.
+ */
+function retraceur_find_coeur_update( $version, $locale ) {
+	$updates = wp_list_filter( retraceur_get_updates(), array( 'version' => $version, 'locale' => $locale ) );
+	$update  = reset( $updates );
+
+	if ( ! $update ) {
+		return false;
+	}
+
+	return $update;
+}
+
+/**
+ * Finds the available update for Retraceur core.
+ *
  * @since WP 2.7.0
+ * @todo deprecate.
  *
  * @param string $version Version string to find the update for.
  * @param string $locale  Locale to find the update for.

--- a/wp-admin/includes/update.php
+++ b/wp-admin/includes/update.php
@@ -16,14 +16,10 @@
  * @return object|array|false The response from the API on success, false on failure.
  */
 function get_preferred_from_update_core() {
-	$updates = get_core_updates();
+	$updates = retraceur_get_updates();
 
-	if ( ! is_array( $updates ) ) {
+	if ( empty( $updates ) || ! is_array( $updates ) ) {
 		return false;
-	}
-
-	if ( empty( $updates ) ) {
-		return (object) array( 'response' => 'latest' );
 	}
 
 	return $updates[0];
@@ -53,7 +49,7 @@ function retraceur_get_updates( $options = array() ) {
 		$dismissed = array();
 	}
 
-	$from_api = get_site_transient( 'retraceur_coeur' );
+	$from_api = get_site_transient( 'update_coeur' );
 
 	if ( ! isset( $from_api->updates ) || ! is_array( $from_api->updates ) ) {
 		return false;
@@ -81,99 +77,6 @@ function retraceur_get_updates( $options = array() ) {
 	}
 
 	return $result;
-}
-
-/**
- * Gets available core updates.
- *
- * @since WP 2.7.0
- * @todo deprecate
- *
- * @param array $options Set $options['dismissed'] to true to show dismissed upgrades too,
- *                       set $options['available'] to false to skip not-dismissed updates.
- * @return array|false Array of the update objects on success, false on failure.
- */
-function get_core_updates( $options = array() ) {
-	$options = array_merge(
-		array(
-			'available' => true,
-			'dismissed' => false,
-		),
-		$options
-	);
-
-	$dismissed = get_site_option( 'dismissed_update_core' );
-
-	if ( ! is_array( $dismissed ) ) {
-		$dismissed = array();
-	}
-
-	$from_api = get_site_transient( 'update_core' );
-
-	if ( ! isset( $from_api->updates ) || ! is_array( $from_api->updates ) ) {
-		return false;
-	}
-
-	$updates = $from_api->updates;
-	$result  = array();
-
-	foreach ( $updates as $update ) {
-		if ( 'autoupdate' === $update->response ) {
-			continue;
-		}
-
-		if ( array_key_exists( $update->current . '|' . $update->locale, $dismissed ) ) {
-			if ( $options['dismissed'] ) {
-				$update->dismissed = true;
-				$result[]          = $update;
-			}
-		} else {
-			if ( $options['available'] ) {
-				$update->dismissed = false;
-				$result[]          = $update;
-			}
-		}
-	}
-
-	return $result;
-}
-
-/**
- * Gets the best available (and enabled) Auto-Update for Retraceur core.
- *
- * If there's 1.2.3 and 1.3 on offer, it'll choose 1.3 if the installation allows it, else, 1.2.3.
- *
- * @since WP 3.7.0
- *
- * @return object|false The core update offering on success, false on failure.
- */
-function find_core_auto_update() {
-	$updates = get_site_transient( 'update_core' );
-
-	if ( ! $updates || empty( $updates->updates ) ) {
-		return false;
-	}
-
-	require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
-
-	$auto_update = false;
-	$upgrader    = new WP_Automatic_Updater();
-
-	foreach ( $updates->updates as $update ) {
-		if ( 'autoupdate' !== $update->response ) {
-			continue;
-		}
-
-		if ( ! $upgrader->should_update( 'core', $update, ABSPATH ) ) {
-			continue;
-		}
-
-		if ( ! $auto_update || version_compare( $update->current, $auto_update->current, '>' ) ) {
-			$auto_update = $update;
-		}
-	}
-
-	return $auto_update;
 }
 
 /**
@@ -230,22 +133,6 @@ function get_core_checksums( $version, $locale ) {
 }
 
 /**
- * Dismisses core update.
- *
- * @since WP 2.7.0
- * @todo deprecate
- *
- * @param object $update
- * @return bool
- */
-function dismiss_core_update( $update ) {
-	$dismissed = get_site_option( 'dismissed_update_core' );
-	$dismissed[ $update->current . '|' . $update->locale ] = true;
-
-	return update_site_option( 'dismissed_update_core', $dismissed );
-}
-
-/**
  * Marks a Retraceur coeur update as dismissed.
  *
  * @since 2.0.0 Retraceur fork.
@@ -261,29 +148,6 @@ function dismiss_coeur_update( $update ) {
 	$dismissed[ $version ] = true;
 
 	return update_site_option( 'dismissed_update_coeur', $dismissed );
-}
-
-/**
- * Undismisses core update.
- *
- * @since WP 2.7.0
- * @todo deprecate
- *
- * @param string $version
- * @param string $locale
- * @return bool
- */
-function undismiss_core_update( $version, $locale ) {
-	$dismissed = get_site_option( 'dismissed_update_core' );
-	$key       = $version . '|' . $locale;
-
-	if ( ! isset( $dismissed[ $key ] ) ) {
-		return false;
-	}
-
-	unset( $dismissed[ $key ] );
-
-	return update_site_option( 'dismissed_update_core', $dismissed );
 }
 
 /**
@@ -326,34 +190,6 @@ function retraceur_find_coeur_update( $version, $locale, $options = array() ) {
 	}
 
 	return $update;
-}
-
-/**
- * Finds the available update for Retraceur core.
- *
- * @since WP 2.7.0
- * @todo deprecate.
- *
- * @param string $version Version string to find the update for.
- * @param string $locale  Locale to find the update for.
- * @return object|false The core update offering on success, false on failure.
- */
-function find_core_update( $version, $locale ) {
-	$from_api = get_site_transient( 'update_core' );
-
-	if ( ! isset( $from_api->updates ) || ! is_array( $from_api->updates ) ) {
-		return false;
-	}
-
-	$updates = $from_api->updates;
-
-	foreach ( $updates as $update ) {
-		if ( $update->current === $version && $update->locale === $locale ) {
-			return $update;
-		}
-	}
-
-	return false;
 }
 
 /**
@@ -1195,7 +1031,7 @@ function wp_is_auto_update_forced_for_item( $type, $update, $item ) {
  * @return string The update message to be shown.
  */
 function wp_get_auto_update_message() {
-	$next_update_time = wp_next_scheduled( 'wp_version_check' );
+	$next_update_time = wp_next_scheduled( 'retraceur_version_check' );
 
 	// Check if the event exists.
 	if ( false === $next_update_time ) {

--- a/wp-admin/includes/update.php
+++ b/wp-admin/includes/update.php
@@ -355,10 +355,14 @@ function update_right_now_message() {
  * Retrieves plugins with updates available.
  *
  * @since WP 2.9.0
+ * @since 2.0.0 Retraceur fork disabled Plugin updates.
  *
  * @return object[]
  */
 function get_plugin_updates() {
+	// Disable Plugin updates for now.
+	return array();
+
 	$all_plugins     = get_plugins();
 	$upgrade_plugins = array();
 	$current         = get_site_transient( 'update_plugins' );
@@ -576,10 +580,14 @@ function wp_plugin_update_row( $file, $plugin_data ) {
  * Retrieves themes with updates available.
  *
  * @since WP 2.9.0
+ * @since 2.0.0 Retraceur fork disabled Theme updates.
  *
  * @return WP_Theme[]
  */
 function get_theme_updates() {
+	// Disable Theme updates for now.
+	return array();
+
 	$current = get_site_transient( 'update_themes' );
 
 	if ( ! isset( $current->response ) ) {

--- a/wp-admin/includes/update.php
+++ b/wp-admin/includes/update.php
@@ -784,62 +784,6 @@ function wp_theme_update_row( $theme_key, $theme ) {
 }
 
 /**
- * Displays maintenance nag HTML message.
- *
- * @since WP 2.7.0
- *
- * @global int $upgrading
- *
- * @return void|false
- */
-function maintenance_nag() {
-	global $upgrading;
-
-	$nag = isset( $upgrading );
-
-	if ( ! $nag ) {
-		$failed = get_site_option( 'auto_core_update_failed' );
-		/*
-		 * If an update failed critically, we may have copied over version.php but not other files.
-		 * In that case, if the installation claims we're running the version we attempted, nag.
-		 * This is serious enough to err on the side of nagging.
-		 *
-		 * If we simply failed to update before we tried to copy any files, then assume things are
-		 * OK if they are now running the latest.
-		 *
-		 * This flag is cleared whenever a successful update occurs using Core_Upgrader.
-		 */
-		$comparison = ! empty( $failed['critical'] ) ? '>=' : '>';
-		if ( isset( $failed['attempted'] ) && version_compare( $failed['attempted'], retraceur_get_version(), $comparison ) ) {
-			$nag = true;
-		}
-	}
-
-	if ( ! $nag ) {
-		return false;
-	}
-
-	if ( current_user_can( 'update_core' ) ) {
-		$msg = sprintf(
-			/* translators: %s: URL to Retraceur Updates screen. */
-			__( 'An automated Retraceur update has failed to complete - <a href="%s">please attempt the update again now</a>.' ),
-			'update-core.php'
-		);
-	} else {
-		$msg = __( 'An automated Retraceur update has failed to complete! Please notify the site administrator.' );
-	}
-
-	wp_admin_notice(
-		$msg,
-		array(
-			'type'               => 'warning',
-			'additional_classes' => array( 'update-nag', 'inline' ),
-			'paragraph_wrap'     => false,
-		)
-	);
-}
-
-/**
  * Prints the JavaScript templates for update admin notices.
  *
  * @since WP 4.6.0

--- a/wp-admin/includes/update.php
+++ b/wp-admin/includes/update.php
@@ -30,9 +30,68 @@ function get_preferred_from_update_core() {
 }
 
 /**
+ * Gets available coeur updates.
+ *
+ * @since 2.0.0 Retraceur fork.
+ *
+ * @param array $options Set $options['dismissed'] to true to show dismissed upgrades too,
+ *                       set $options['available'] to false to skip not-dismissed updates.
+ * @return array|false Array of the update arrays on success, false on failure.
+ */
+function retraceur_get_updates( $options = array() ) {
+	$options = array_merge(
+		array(
+			'available' => true,
+			'dismissed' => false,
+		),
+		$options
+	);
+
+	$dismissed = get_site_option( 'dismissed_update_coeur' );
+
+	if ( ! is_array( $dismissed ) ) {
+		$dismissed = array();
+	}
+
+	$from_api = get_site_transient( 'retraceur_coeur' );
+
+	if ( ! isset( $from_api->updates ) || ! is_array( $from_api->updates ) ) {
+		return false;
+	}
+
+	$updates = wp_list_sort( $from_api->updates, 'date', 'DESC' );
+	$result  = array();
+
+	foreach ( $updates as $update ) {
+		if ( true !== $update['stable'] ) {
+			continue;
+		}
+
+		if ( current( $updates ) === count( $updates ) - 1 ) {
+			$update['latest'] = true;
+		}
+
+		if ( array_key_exists( $update['version'], $dismissed ) ) {
+			if ( $options['dismissed'] ) {
+				$update['dismissed'] = true;
+				$result[]            = $update;
+			}
+		} else {
+			if ( $options['available'] ) {
+				$update['dismissed'] = false;
+				$result[]            = $update;
+			}
+		}
+	}
+
+	return $result;
+}
+
+/**
  * Gets available core updates.
  *
  * @since WP 2.7.0
+ * @todo deprecate
  *
  * @param array $options Set $options['dismissed'] to true to show dismissed upgrades too,
  *                       set $options['available'] to false to skip not-dismissed updates.

--- a/wp-admin/includes/update.php
+++ b/wp-admin/includes/update.php
@@ -233,6 +233,7 @@ function get_core_checksums( $version, $locale ) {
  * Dismisses core update.
  *
  * @since WP 2.7.0
+ * @todo deprecate
  *
  * @param object $update
  * @return bool
@@ -245,9 +246,28 @@ function dismiss_core_update( $update ) {
 }
 
 /**
+ * Marks a Retraceur coeur update as dismissed.
+ *
+ * @since 2.0.0 Retraceur fork.
+ *
+ * @param object array
+ * @return bool
+ */
+function dismiss_coeur_update( $update ) {
+	$dismissed = get_site_option( 'dismissed_update_coeur' );
+	$version   = $update['version'];
+
+	// Mark the version as dismissed.
+	$dismissed[ $version ] = true;
+
+	return update_site_option( 'dismissed_update_coeur', $dismissed );
+}
+
+/**
  * Undismisses core update.
  *
  * @since WP 2.7.0
+ * @todo deprecate
  *
  * @param string $version
  * @param string $locale
@@ -267,16 +287,38 @@ function undismiss_core_update( $version, $locale ) {
 }
 
 /**
+ * Remove a coeur update from dissmissed ones.
+ *
+ * @since 2.0.0 Retraceur fork.
+ *
+ * @param string $version The version number.
+ * @return bool
+ */
+function undismiss_coeur_update( $version ) {
+	$dismissed = get_site_option( 'dismissed_update_coeur' );
+
+	if ( ! isset( $dismissed[ $version ] ) ) {
+		return false;
+	}
+
+	unset( $dismissed[ $version ] );
+
+	return update_site_option( 'dismissed_update_coeur', $dismissed );
+}
+
+/**
  * Finds the available update for Retraceur core.
  *
  * @since 2.0.0 Retraceur fork.
  *
  * @param string $version Version string to find the update for.
  * @param string $locale  Locale to find the update for.
+ * @param array  $options Set $options['dismissed'] to true to show dismissed upgrades too,
+ *                        set $options['available'] to false to skip not-dismissed updates.
  * @return array|false The core update offering on success, false on failure.
  */
-function retraceur_find_coeur_update( $version, $locale ) {
-	$updates = wp_list_filter( retraceur_get_updates(), array( 'version' => $version, 'locale' => $locale ) );
+function retraceur_find_coeur_update( $version, $locale, $options = array() ) {
+	$updates = wp_list_filter( retraceur_get_updates( $options ), array( 'version' => $version, 'locale' => $locale ) );
 	$update  = reset( $updates );
 
 	if ( ! $update ) {

--- a/wp-admin/includes/upgrade.php
+++ b/wp-admin/includes/upgrade.php
@@ -70,11 +70,11 @@ if ( ! function_exists( 'wp_install' ) ) :
 		 * This prevents users being presented with a maintenance mode screen
 		 * immediately after installation.
 		 */
-		wp_unschedule_hook( 'wp_version_check' );
+		wp_unschedule_hook( 'retraceur_version_check' );
 		wp_unschedule_hook( 'wp_update_plugins' );
 		wp_unschedule_hook( 'wp_update_themes' );
 
-		wp_schedule_event( time() + HOUR_IN_SECONDS, 'twicedaily', 'wp_version_check' );
+		wp_schedule_event( time() + HOUR_IN_SECONDS, 'twicedaily', 'retraceur_version_check' );
 		wp_schedule_event( time() + ( 1.5 * HOUR_IN_SECONDS ), 'twicedaily', 'wp_update_plugins' );
 		wp_schedule_event( time() + ( 2 * HOUR_IN_SECONDS ), 'twicedaily', 'wp_update_themes' );
 
@@ -680,7 +680,7 @@ function upgrade_all() {
 
 	populate_options();
 
-	if ( 20250621 > $wp_current_db_version ) {
+	if ( 20250711 > $wp_current_db_version ) {
 		create_post_formats();
 	}
 

--- a/wp-admin/includes/upgrade.php
+++ b/wp-admin/includes/upgrade.php
@@ -71,12 +71,28 @@ if ( ! function_exists( 'wp_install' ) ) :
 		 * immediately after installation.
 		 */
 		wp_unschedule_hook( 'retraceur_version_check' );
-		wp_unschedule_hook( 'wp_update_plugins' );
-		wp_unschedule_hook( 'wp_update_themes' );
+
+		/**
+		 * @todo Restore when Retraceur adpated its API to handle it.
+		 */
+		// wp_unschedule_hook( 'wp_update_plugins' );
+
+		/**
+		 * @todo Restore when Retraceur adpated its API to handle it.
+		 */
+		// wp_unschedule_hook( 'wp_update_themes' );
 
 		wp_schedule_event( time() + HOUR_IN_SECONDS, 'twicedaily', 'retraceur_version_check' );
-		wp_schedule_event( time() + ( 1.5 * HOUR_IN_SECONDS ), 'twicedaily', 'wp_update_plugins' );
-		wp_schedule_event( time() + ( 2 * HOUR_IN_SECONDS ), 'twicedaily', 'wp_update_themes' );
+
+		/**
+		 * @todo Restore when Retraceur adpated its API to handle it.
+		 */
+		// wp_schedule_event( time() + ( 1.5 * HOUR_IN_SECONDS ), 'twicedaily', 'wp_update_plugins' );
+
+		/**
+		 * @todo Restore when Retraceur adpated its API to handle it.
+		 */
+		// wp_schedule_event( time() + ( 2 * HOUR_IN_SECONDS ), 'twicedaily', 'wp_update_themes' );
 
 		populate_options();
 		populate_roles();

--- a/wp-admin/update-core.php
+++ b/wp-admin/update-core.php
@@ -284,8 +284,12 @@ function core_upgrade_preamble() {
  * Display the upgrade plugins form.
  *
  * @since WP 2.9.0
+ * @since 2.0.0 Retraceur fork disabled the Plugin updates.
  */
 function list_plugin_updates() {
+	// Disable Plugin updates for now.
+	return '';
+
 	$retraceur_version = retraceur_get_version();
 	$cur_r_version     = preg_replace( '/-.*$/', '', $retraceur_version );
 
@@ -450,8 +454,12 @@ function list_plugin_updates() {
  * Display the upgrade themes form.
  *
  * @since WP 2.9.0
+ * @since 2.0.0 Retraceur fork disabled the Theme updates.
  */
 function list_theme_updates() {
+	// Disable Theme updates for now.
+	return '';
+
 	$themes = get_theme_updates();
 	if ( empty( $themes ) ) {
 		echo '<h2>' . __( 'Themes' ) . '</h2>';
@@ -587,8 +595,12 @@ function list_theme_updates() {
  * Display the update translations form.
  *
  * @since WP 3.7.0
+ * @since 2.0.0 Retraceur fork disabled the Translation updates.
  */
 function list_translation_updates() {
+	// Disable Translation updates for now.
+	return '';
+
 	$updates = wp_get_translation_updates();
 	if ( ! $updates ) {
 		if ( 'en_US' !== get_locale() ) {
@@ -962,6 +974,11 @@ if ( 'upgrade-core' === $action ) {
 	require_once ABSPATH . 'wp-admin/admin-footer.php';
 
 } elseif ( 'do-plugin-upgrade' === $action ) {
+	wp_die(
+		'<h1>' . __( 'Retraceur does not provide an API to update plugins yet.' ) . '</h1>' .
+		'<p>' . __( 'You can always go to the Plugin’s "Add new" screen to upload and replace outdated packages.' ) . '</p>',
+		500
+	);
 
 	if ( ! current_user_can( 'update_plugins' ) ) {
 		wp_die( __( 'Sorry, you are not allowed to update this site.' ) );
@@ -1003,6 +1020,11 @@ if ( 'upgrade-core' === $action ) {
 	require_once ABSPATH . 'wp-admin/admin-footer.php';
 
 } elseif ( 'do-theme-upgrade' === $action ) {
+	wp_die(
+		'<h1>' . __( 'Retraceur does not provide an API to update themes yet.' ) . '</h1>' .
+		'<p>' . __( 'You can always go to the Theme’s "Add new" screen to upload and replace outdated packages.' ) . '</p>',
+		500
+	);
 
 	if ( ! current_user_can( 'update_themes' ) ) {
 		wp_die( __( 'Sorry, you are not allowed to update this site.' ) );
@@ -1044,6 +1066,7 @@ if ( 'upgrade-core' === $action ) {
 	require_once ABSPATH . 'wp-admin/admin-footer.php';
 
 } elseif ( 'do-translation-upgrade' === $action ) {
+	wp_die( __( 'Retraceur does not provide an API to update languages yet.' ), 500 );
 
 	if ( ! current_user_can( 'update_languages' ) ) {
 		wp_die( __( 'Sorry, you are not allowed to update this site.' ) );

--- a/wp-admin/update-core.php
+++ b/wp-admin/update-core.php
@@ -214,7 +214,7 @@ function core_upgrade_preamble() {
 
 	if ( ! $updates ) {
 		wp_admin_notice(
-			__( 'No Retraceur core updates were found for now.' ),
+			__( 'No Retraceur Coeur updates were found for now.' ),
 			array(
 				'type'               => 'info',
 				'additional_classes' => array( 'inline' ),

--- a/wp-admin/update-core.php
+++ b/wp-admin/update-core.php
@@ -46,8 +46,17 @@ function retraceur_list_update( $update ) {
 	$form_action   = 'update-core.php?action=do-core-upgrade';
 	$php_version   = PHP_VERSION;
 	$mysql_version = $wpdb->db_version();
-	$show_buttons  = true;
-	$submit        = sprintf( __( 'Update to version %s' ), $version_string );
+
+	/**
+	 * Filter to opt-in for Coeur "direct" updates (still in beta).
+	 *
+	 * @since 2.0.0 Retraceur fork.
+	 *
+	 * @param boolean $test True to test "direct" updates. False otherwise.
+	 */
+	$show_buttons = apply_filters( 'retraceur_betatest_direct_updates', false );
+	$submit       = sprintf( __( 'Update to version %s' ), $version_string );
+	$link_text    = sprintf( __( 'Download & upgrade to version %s' ), $version_string );
 
 	if ( $current ) {
 		/* translators: %s: Version number. */
@@ -124,6 +133,20 @@ function retraceur_list_update( $update ) {
 		} else {
 			submit_button( $submit, '', 'upgrade', false );
 		}
+	}
+
+	// Provide a simple download link to people wishing to manually update.
+	if ( isset( $update['download'] ) ) {
+		$link_class = ! $show_buttons && $first_pass ? 'button-primary' : 'button-secondary';
+		$first_pass = false;
+		$package    = $update['download'];
+
+		if ( 'fr_FR' === $update['locale'] ) {
+			$package = str_replace( 'retraceur.zip', 'retraceur-fr_FR.zip', $package );
+		}
+		?>
+		<a class="button<?php echo ' ' . $link_class; ?> download-package" href="<?php echo esc_url( $package ); ?>" aria-label="<?php echo esc_attr( $link_text ); ?>"><?php echo esc_html( $link_text ); ?></a>
+		<?php
 	}
 
 	if ( ! isset( $update['dismissed'] ) || ! $update['dismissed'] ) {
@@ -778,17 +801,13 @@ get_current_screen()->add_help_tab(
 	)
 );
 
-$updates_howto  = '<p>' . __( '<strong>Retraceur</strong> &mdash; Updating your Retraceur installation is a simple one-click procedure: just <strong>click on the &#8220;Update now&#8221; button</strong> when you are notified that a new version is available.' ) . ' ' . __( 'In most cases, Retraceur will automatically apply maintenance and security updates in the background for you.' ) . '</p>';
-$updates_howto .= '<p>' . __( '<strong>Themes and Plugins</strong> &mdash; To update individual themes or plugins from this screen, use the checkboxes to make your selection, then <strong>click on the appropriate &#8220;Update&#8221; button</strong>. To update all of your themes or plugins at once, you can check the box at the top of the section to select all before clicking the update button.' ) . '</p>';
+$updates_howto  = '<p>' . __( '<strong>Retraceur</strong> &mdash; Updating your Retraceur installation is a simple one-click procedure: just <strong>click on the &#8220;Update to version X.Y.Z&#8221; button</strong> when you are notified that a new version is available.' ) . ' ' . __( 'Alternatively, you can perform a manual upgrade using the &#8220;Download & upgrade to version X.Y.Z&#8221; button.' ) . '</p>';
+/*$updates_howto .= '<p>' . __( '<strong>Themes and Plugins</strong> &mdash; To update individual themes or plugins from this screen, use the checkboxes to make your selection, then <strong>click on the appropriate &#8220;Update&#8221; button</strong>. To update all of your themes or plugins at once, you can check the box at the top of the section to select all before clicking the update button.' ) . '</p>';
 
 if ( 'en_US' !== get_locale() ) {
 	$updates_howto .= '<p>' . __( '<strong>Translations</strong> &mdash; The files translating Retraceur into your language are updated for you whenever any other updates occur. But if these files are out of date, you can <strong>click the &#8220;Update Translations&#8221;</strong> button.' ) . '</p>';
-}
+}*/
 
-/*
- * Disable this for now.
- * @todo Restore when the Retraceur Update API will be ready.
- *
 get_current_screen()->add_help_tab(
 	array(
 		'id'      => 'how-to-update',
@@ -796,7 +815,11 @@ get_current_screen()->add_help_tab(
 		'content' => $updates_howto,
 	)
 );
-*/
+
+get_current_screen()->set_help_sidebar(
+	'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
+	'<p>' . sprintf( __( '<a href="%s">Documentation on manual upgrades</a>' ), esc_url( _x( 'https://retraceur.github.io/getting-started/upgrade/', 'Documentation site link' ) ) ) . '</p>'
+);
 
 if ( 'upgrade-core' === $action ) {
 	// Force an update check when requested.

--- a/wp-admin/update-core.php
+++ b/wp-admin/update-core.php
@@ -26,9 +26,120 @@ if ( ! current_user_can( 'update_core' ) && ! current_user_can( 'update_themes' 
 }
 
 /**
+ * Lists available coeur updates.
+ *
+ * @since 2.0.0 Retraceur fork.
+ *
+ * @global wpdb $wpdb Retraceur database abstraction object.
+ *
+ * @param array $update
+ */
+function retraceur_list_update( $update ) {
+	global $wpdb;
+	static $first_pass = true;
+
+	$retraceur_version  = retraceur_get_version();
+	$version_string     = $update['version'];
+	$current            = $retraceur_version === $update['version'];
+
+	$message       = '';
+	$form_action   = 'update-core.php?action=do-core-upgrade';
+	$php_version   = PHP_VERSION;
+	$mysql_version = $wpdb->db_version();
+	$show_buttons  = true;
+	$submit        = sprintf( __( 'Update to version %s' ), $version_string );
+
+	if ( $current ) {
+		/* translators: %s: Version number. */
+		$submit      = sprintf( __( 'Re-install version %s' ), $version_string );
+		$form_action = 'update-core.php?action=do-core-reinstall';
+	} else {
+		$needs_php  = ! empty( $update['requirements']['php'] ) ? $update['requirements']['php'] : '';
+		$php_compat = true;
+
+		if ( $needs_php ) {
+			$php_compat = version_compare( $php_version, $needs_php, '>=' );
+		}
+
+		$needs_mysql  = ! empty( $update['requirements']['mysql'] ) ? $update['requirements']['mysql'] : '';
+		$mysql_compat = true;
+		if ( ! file_exists( WP_CONTENT_DIR . '/db.php' ) || empty( $wpdb->is_mysql ) && $needs_mysql ) {
+			$mysql_compat = version_compare( $mysql_version, $needs_mysql, '>=' );
+		}
+
+		if ( ! $mysql_compat && ! $php_compat ) {
+			$message = sprintf(
+				/* translators: 1: Retraceur version number, 2: Minimum required PHP version number, 3: Minimum required MySQL version number, 4: Current PHP version number, 5: Current MySQL version number. */
+				__( 'You cannot update because Retraceur %1$s requires PHP version %2$s or higher and MySQL version %3$s or higher. You are running PHP version %4$s and MySQL version %5$s.' ),
+				$update['version'],
+				$needs_php,
+				$needs_mysql,
+				$php_version,
+				$mysql_version
+			);
+		} elseif ( ! $php_compat ) {
+			$message = sprintf(
+				/* translators: 1: Retraceur version number, 2: Minimum required PHP version number, 3: Current PHP version number. */
+				__( 'You cannot update because Retraceur %1$s requires PHP version %2$s or higher. You are running version %3$s.' ),
+				$update['version'],
+				$needs_php,
+				$php_version
+			);
+		} elseif ( ! $mysql_compat ) {
+			$message = sprintf(
+				/* translators: 1: Retraceur version number, 2: Minimum required MySQL version number, 3: Current MySQL version number. */
+				__( 'You cannot update because Retraceur %1$s requires MySQL version %2$s or higher. You are running version %3$s.' ),
+				$update['version'],
+				$needs_mysql,
+				$mysql_version
+			);
+		} else {
+			$message = sprintf(
+				/* translators: 1: Installed Retraceur version number, 2: New Retraceur version number, including locale if necessary. */
+				__( 'You can update from Retraceur %1$s to Retraceur %2$s manually:' ),
+				$retraceur_version,
+				$version_string
+			);
+		}
+
+		if ( ! $mysql_compat || ! $php_compat ) {
+			$show_buttons = false;
+		}
+	}
+
+	echo '<p>';
+	echo $message;
+	echo '</p>';
+
+	echo '<form method="post" action="' . esc_url( $form_action ) . '" name="upgrade" class="upgrade">';
+	wp_nonce_field( 'upgrade-core' );
+
+	echo '<p>';
+	echo '<input name="version" value="' . esc_attr( $update['version'] ) . '" type="hidden" />';
+	if ( $show_buttons ) {
+		if ( $first_pass ) {
+			submit_button( $submit, $current ? '' : 'primary regular', 'upgrade', false );
+			$first_pass = false;
+		} else {
+			submit_button( $submit, '', 'upgrade', false );
+		}
+	}
+
+	if ( ! isset( $update['dismissed'] ) || ! $update['dismissed'] ) {
+		submit_button( __( 'Hide this update' ), '', 'dismiss', false );
+	} else {
+		submit_button( __( 'Bring back this update' ), '', 'undismiss', false );
+	}
+
+	echo '</p>';
+	echo '</form>';
+}
+
+/**
  * Lists available core updates.
  *
  * @since WP 2.7.0
+ * @todo deprecate
  *
  * @global string $wp_local_package Locale code of the package.
  * @global wpdb   $wpdb             Retraceur database abstraction object.
@@ -210,7 +321,7 @@ function dismissed_updates() {
 		echo '<ul id="dismissed-updates" class="core-updates dismissed">';
 		foreach ( (array) $dismissed as $update ) {
 			echo '<li>';
-			list_core_update( $update );
+			retraceur_list_update( $update );
 			echo '</li>';
 		}
 		echo '</ul>';
@@ -223,9 +334,16 @@ function dismissed_updates() {
  * @since WP 2.7.0
  */
 function core_upgrade_preamble() {
-	$updates = get_core_updates();
+	$updates = retraceur_get_updates();
 
 	if ( ! $updates ) {
+		wp_admin_notice(
+			__( 'No Retraceur core updates were found for now.' ),
+			array(
+				'type'               => 'info',
+				'additional_classes' => array( 'inline' ),
+			)
+		);
 		return;
 	}
 
@@ -234,9 +352,9 @@ function core_upgrade_preamble() {
 
 	$is_development_version = preg_match( '/alpha|beta|RC/', $retraceur_version );
 
-	if ( isset( $updates[0]->version ) && version_compare( $updates[0]->version, $retraceur_version, '>' ) ) {
+	if ( isset( $updates[0]['version'] ) && version_compare( $updates[0]['version'], $retraceur_version, '>' ) ) {
 		echo '<h2 class="response">';
-		_e( 'An updated version of Retraceur is available.' );
+		esc_html_e( 'An updated version of Retraceur is available.' );
 		echo '</h2>';
 
 		wp_admin_notice(
@@ -254,14 +372,19 @@ function core_upgrade_preamble() {
 
 	echo '<ul class="core-updates">';
 	foreach ( (array) $updates as $update ) {
+		// Disable older stable version than current.
+		if ( version_compare( $update['version'], $retraceur_version, '<=' ) ) {
+			continue;
+		}
+
 		echo '<li>';
-		list_core_update( $update );
+		retraceur_list_update( $update );
 		echo '</li>';
 	}
 	echo '</ul>';
 
 	// Don't show the maintenance mode notice when we are only showing a single re-install option.
-	if ( $updates && ( count( $updates ) > 1 || 'latest' !== $updates[0]->response ) ) {
+	if ( $updates && count( $updates ) > 1 ) {
 		echo '<p>' . __( 'While your site is being updated, it will be in maintenance mode. As soon as your updates are complete, this mode will be deactivated.' ) . '</p>';
 	} elseif ( ! $updates ) {
 		list( $normalized_version ) = explode( '-', $retraceur_version );
@@ -280,6 +403,7 @@ function core_upgrade_preamble() {
  * Display Retraceur auto-updates settings.
  *
  * @since WP 5.6.0
+ * @todo deprecate as Retraceur won't use auto-updates.
  */
 function core_auto_updates_settings() {
 	if ( isset( $_GET['core-major-auto-updates-saved'] ) ) {
@@ -1033,8 +1157,7 @@ if ( 'upgrade-core' === $action ) {
 	echo '</p>';
 
 	if ( current_user_can( 'update_core' ) ) {
-		core_auto_updates_settings();
-		//core_upgrade_preamble();
+		core_upgrade_preamble();
 	}
 
 	/*

--- a/wp-admin/update-core.php
+++ b/wp-admin/update-core.php
@@ -137,155 +137,6 @@ function retraceur_list_update( $update ) {
 }
 
 /**
- * Lists available core updates.
- *
- * @since WP 2.7.0
- * @todo deprecate
- *
- * @global string $wp_local_package Locale code of the package.
- * @global wpdb   $wpdb             Retraceur database abstraction object.
- *
- * @param object $update
- */
-function list_core_update( $update ) {
-	global $wp_local_package, $wpdb;
-	static $first_pass = true;
-
-	$retraceur_version  = retraceur_get_version();
-	$version_string     = sprintf( '%s&ndash;%s', $update->current, get_locale() );
-
-	if ( 'en_US' === $update->locale && 'en_US' === get_locale() ) {
-		$version_string = $update->current;
-	} elseif ( 'en_US' === $update->locale && $update->packages->partial && $retraceur_version === $update->partial_version ) {
-		$updates = get_core_updates();
-		if ( $updates && 1 === count( $updates ) ) {
-			// If the only available update is a partial builds, it doesn't need a language-specific version string.
-			$version_string = $update->current;
-		}
-	} elseif ( 'en_US' === $update->locale && 'en_US' !== get_locale() ) {
-		$version_string = sprintf( '%s&ndash;%s', $update->current, $update->locale );
-	}
-
-	$current = false;
-	if ( ! isset( $update->response ) || 'latest' === $update->response ) {
-		$current = true;
-	}
-
-	$message       = '';
-	$form_action   = 'update-core.php?action=do-core-upgrade';
-	$php_version   = PHP_VERSION;
-	$mysql_version = $wpdb->db_version();
-	$show_buttons  = true;
-
-	// Nightly build versions have two hyphens and a commit number.
-	if ( preg_match( '/-\w+-\d+/', $update->current ) ) {
-		// Retrieve the major version number.
-		preg_match( '/^\d+.\d+/', $update->current, $update_major );
-		/* translators: %s: Version number. */
-		$submit = sprintf( __( 'Update to latest %s nightly' ), $update_major[0] );
-	} else {
-		/* translators: %s: Version number. */
-		$submit = sprintf( __( 'Update to version %s' ), $version_string );
-	}
-
-	if ( 'development' === $update->response ) {
-		$message = __( 'You can update to the latest nightly build manually:' );
-	} else {
-		if ( $current ) {
-			/* translators: %s: Version number. */
-			$submit      = sprintf( __( 'Re-install version %s' ), $version_string );
-			$form_action = 'update-core.php?action=do-core-reinstall';
-		} else {
-			$php_compat = version_compare( $php_version, $update->php_version, '>=' );
-			if ( file_exists( WP_CONTENT_DIR . '/db.php' ) && empty( $wpdb->is_mysql ) ) {
-				$mysql_compat = true;
-			} else {
-				$mysql_compat = version_compare( $mysql_version, $update->mysql_version, '>=' );
-			}
-
-			if ( ! $mysql_compat && ! $php_compat ) {
-				$message = sprintf(
-					/* translators: 1: Retraceur version number, 2: Minimum required PHP version number, 3: Minimum required MySQL version number, 4: Current PHP version number, 5: Current MySQL version number. */
-					__( 'You cannot update because Retraceur %1$s requires PHP version %2$s or higher and MySQL version %3$s or higher. You are running PHP version %4$s and MySQL version %5$s.' ),
-					$update->current,
-					$update->php_version,
-					$update->mysql_version,
-					$php_version,
-					$mysql_version
-				);
-			} elseif ( ! $php_compat ) {
-				$message = sprintf(
-					/* translators: 1: Retraceur version number, 2: Minimum required PHP version number, 3: Current PHP version number. */
-					__( 'You cannot update because Retraceur %1$s requires PHP version %2$s or higher. You are running version %3$s.' ),
-					$update->current,
-					$update->php_version,
-					$php_version
-				);
-			} elseif ( ! $mysql_compat ) {
-				$message = sprintf(
-					/* translators: 1: Retraceur version number, 2: Minimum required MySQL version number, 3: Current MySQL version number. */
-					__( 'You cannot update because Retraceur %1$s requires MySQL version %2$s or higher. You are running version %3$s.' ),
-					$update->current,
-					$update->mysql_version,
-					$mysql_version
-				);
-			} else {
-				$message = sprintf(
-					/* translators: 1: Installed Retraceur version number, 2: New Retraceur version number, including locale if necessary. */
-					__( 'You can update from Retraceur %1$s to Retraceur %2$s manually:' ),
-					$retraceur_version,
-					$version_string
-				);
-			}
-
-			if ( ! $mysql_compat || ! $php_compat ) {
-				$show_buttons = false;
-			}
-		}
-	}
-
-	echo '<p>';
-	echo $message;
-	echo '</p>';
-
-	echo '<form method="post" action="' . esc_url( $form_action ) . '" name="upgrade" class="upgrade">';
-	wp_nonce_field( 'upgrade-core' );
-
-	echo '<p>';
-	echo '<input name="version" value="' . esc_attr( $update->current ) . '" type="hidden" />';
-	echo '<input name="locale" value="' . esc_attr( $update->locale ) . '" type="hidden" />';
-	if ( $show_buttons ) {
-		if ( $first_pass ) {
-			submit_button( $submit, $current ? '' : 'primary regular', 'upgrade', false );
-			$first_pass = false;
-		} else {
-			submit_button( $submit, '', 'upgrade', false );
-		}
-	}
-	if ( 'en_US' !== $update->locale ) {
-		if ( ! isset( $update->dismissed ) || ! $update->dismissed ) {
-			submit_button( __( 'Hide this update' ), '', 'dismiss', false );
-		} else {
-			submit_button( __( 'Bring back this update' ), '', 'undismiss', false );
-		}
-	}
-	echo '</p>';
-
-	if ( 'en_US' !== $update->locale && ( ! isset( $wp_local_package ) || $wp_local_package !== $update->locale ) ) {
-		echo '<p class="hint">' . __( 'This localized version contains both the translation and various other localization fixes.' ) . '</p>';
-	} elseif ( 'en_US' === $update->locale && 'en_US' !== get_locale() && ( ! $update->packages->partial && $retraceur_version === $update->partial_version ) ) {
-		// Partial builds don't need language-specific warnings.
-		echo '<p class="hint">' . sprintf(
-			/* translators: %s: Retraceur version. */
-			__( 'You are about to install Retraceur %s <strong>in English (US)</strong>. There is a chance this update will break your translation. You may prefer to wait for the localized version to be released.' ),
-			'development' !== $update->response ? $update->current : ''
-		) . '</p>';
-	}
-
-	echo '</form>';
-}
-
-/**
  * Display dismissed updates.
  *
  * @since WP 2.7.0
@@ -407,188 +258,13 @@ function core_upgrade_preamble() {
 }
 
 /**
- * Display Retraceur auto-updates settings.
- *
- * @since WP 5.6.0
- * @todo deprecate as Retraceur won't use auto-updates.
- */
-function core_auto_updates_settings() {
-	if ( isset( $_GET['core-major-auto-updates-saved'] ) ) {
-		if ( 'enabled' === $_GET['core-major-auto-updates-saved'] ) {
-			$notice_text = __( 'Automatic updates for all Retraceur versions have been enabled. Thank you!' );
-			wp_admin_notice(
-				$notice_text,
-				array(
-					'type'        => 'success',
-					'dismissible' => true,
-				)
-			);
-		} elseif ( 'disabled' === $_GET['core-major-auto-updates-saved'] ) {
-			$notice_text = __( 'Retraceur will only receive automatic security and maintenance releases from now on.' );
-			wp_admin_notice(
-				$notice_text,
-				array(
-					'type'        => 'success',
-					'dismissible' => true,
-				)
-			);
-		}
-	}
-
-	require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
-	$updater = new WP_Automatic_Updater();
-
-	// Defaults:
-	$upgrade_dev   = get_site_option( 'auto_update_core_dev', 'enabled' ) === 'enabled';
-	$upgrade_minor = get_site_option( 'auto_update_core_minor', 'enabled' ) === 'enabled';
-	$upgrade_major = get_site_option( 'auto_update_core_major', 'unset' ) === 'enabled';
-
-	$can_set_update_option = true;
-	// WP_AUTO_UPDATE_CORE = true (all), 'beta', 'rc', 'development', 'branch-development', 'minor', false.
-	if ( defined( 'WP_AUTO_UPDATE_CORE' ) ) {
-		if ( false === WP_AUTO_UPDATE_CORE ) {
-			// Defaults to turned off, unless a filter allows it.
-			$upgrade_dev   = false;
-			$upgrade_minor = false;
-			$upgrade_major = false;
-		} elseif ( true === WP_AUTO_UPDATE_CORE
-			|| in_array( WP_AUTO_UPDATE_CORE, array( 'beta', 'rc', 'development', 'branch-development' ), true )
-		) {
-			// ALL updates for core.
-			$upgrade_dev   = true;
-			$upgrade_minor = true;
-			$upgrade_major = true;
-		} elseif ( 'minor' === WP_AUTO_UPDATE_CORE ) {
-			// Only minor updates for core.
-			$upgrade_dev   = false;
-			$upgrade_minor = true;
-			$upgrade_major = false;
-		}
-
-		// The UI is overridden by the `WP_AUTO_UPDATE_CORE` constant.
-		$can_set_update_option = false;
-	}
-
-	if ( $updater->is_disabled() ) {
-		$upgrade_dev   = false;
-		$upgrade_minor = false;
-		$upgrade_major = false;
-
-		/*
-		 * The UI is overridden by the `AUTOMATIC_UPDATER_DISABLED` constant
-		 * or the `automatic_updater_disabled` filter,
-		 * or by `wp_is_file_mod_allowed( 'automatic_updater' )`.
-		 * See `WP_Automatic_Updater::is_disabled()`.
-		 */
-		$can_set_update_option = false;
-	}
-
-	// Is the UI overridden by a plugin using the `allow_major_auto_core_updates` filter?
-	if ( has_filter( 'allow_major_auto_core_updates' ) ) {
-		$can_set_update_option = false;
-	}
-
-	/** This filter is documented in wp-admin/includes/class-core-upgrader.php */
-	$upgrade_dev = apply_filters( 'allow_dev_auto_core_updates', $upgrade_dev );
-	/** This filter is documented in wp-admin/includes/class-core-upgrader.php */
-	$upgrade_minor = apply_filters( 'allow_minor_auto_core_updates', $upgrade_minor );
-	/** This filter is documented in wp-admin/includes/class-core-upgrader.php */
-	$upgrade_major = apply_filters( 'allow_major_auto_core_updates', $upgrade_major );
-
-	$auto_update_settings = array(
-		'dev'   => $upgrade_dev,
-		'minor' => $upgrade_minor,
-		'major' => $upgrade_major,
-	);
-
-	if ( $upgrade_major ) {
-		$retraceur_version = retraceur_get_version();
-		$updates           = get_core_updates();
-
-		if ( isset( $updates[0]->version ) && version_compare( $updates[0]->version, $retraceur_version, '>' ) ) {
-			echo '<p>' . wp_get_auto_update_message() . '</p>';
-		}
-	}
-
-	$action_url = self_admin_url( 'update-core.php?action=core-major-auto-updates-settings' );
-	?>
-
-	<p class="auto-update-status">
-		<?php
-		/*
-		 * Disable this for now.
-		 * @todo Restore when the Retraceur Update API will be ready.
-		 *
-		if ( $updater->is_vcs_checkout( ABSPATH ) ) {
-			esc_html_e( 'This site appears to be under version control. Automatic updates are disabled.' );
-		} elseif ( $upgrade_major ) {
-			esc_html_e( 'This site is automatically kept up to date with each new version of Retraceur.' );
-
-			if ( $can_set_update_option ) {
-				echo '<br />';
-				printf(
-					'<a href="%s" class="core-auto-update-settings-link core-auto-update-settings-link-disable">%s</a>',
-					wp_nonce_url( add_query_arg( 'value', 'disable', $action_url ), 'core-major-auto-updates-nonce' ),
-					__( 'Switch to automatic updates for maintenance and security releases only.' )
-				);
-			}
-		} elseif ( $upgrade_minor ) {
-			esc_html_e( 'This site is automatically kept up to date with maintenance and security releases of Retraceur only.' );
-
-			if ( $can_set_update_option ) {
-				echo '<br />';
-				printf(
-					'<a href="%s" class="core-auto-update-settings-link core-auto-update-settings-link-enable">%s</a>',
-					wp_nonce_url( add_query_arg( 'value', 'enable', $action_url ), 'core-major-auto-updates-nonce' ),
-					__( 'Enable automatic updates for all new versions of Retraceur.' )
-				);
-			}
-		} else {
-			esc_html_e( 'This site will not receive automatic updates for new versions of Retraceur.' );
-		}
-		*/
-		?>
-		<strong><?php esc_html_e( 'The Retraceur automatic update feature is not available yet' ); ?></strong><br />
-		<?php
-		printf(
-			/* Translators: %s: the Retraceur GitHub releases link. */
-			esc_html__( 'In the meantime, please: do often %s.' ),
-			'<a href="https://github.com/retraceur/coeur/releases" target="_blank">' . esc_html_x( 'check for updates manually', 'update core screen' ) . '</a>'
-		);
-		echo '&nbsp;';
-		printf(
-			/* Translators: %s: the documentation link about manual upgrades. */
-			esc_html__( 'When a new version will be available, you will need to upgrade Retraceur core manually. Please read more about it in this %s.' ),
-			'<a href="' . esc_url( _x( 'https://retraceur.github.io/getting-started/upgrade/', 'documentation URL' ) ) . '" target="_blank">' . esc_html__( 'documentation chapter' ) . '</a>'
-		);
-		?>
-	</p>
-
-	<?php
-	/**
-	 * Fires after the major core auto-update settings.
-	 *
-	 * @since WP 5.6.0
-	 *
-	 * @param array $auto_update_settings {
-	 *     Array of core auto-update settings.
-	 *
-	 *     @type bool $dev   Whether to enable automatic updates for development versions.
-	 *     @type bool $minor Whether to enable minor automatic core updates.
-	 *     @type bool $major Whether to enable major automatic core updates.
-	 * }
-	 */
-	do_action( 'after_core_auto_updates_settings', $auto_update_settings );
-}
-
-/**
  * Display the upgrade plugins form.
  *
  * @since WP 2.9.0
  */
 function list_plugin_updates() {
 	$retraceur_version = retraceur_get_version();
-	$cur_wp_version    = preg_replace( '/-.*$/', '', $retraceur_version );
+	$cur_r_version     = preg_replace( '/-.*$/', '', $retraceur_version );
 
 	require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 	$plugins = get_plugin_updates();
@@ -599,11 +275,11 @@ function list_plugin_updates() {
 	}
 	$form_action = 'update-core.php?action=do-plugin-upgrade';
 
-	$core_updates = get_core_updates();
-	if ( ! isset( $core_updates[0]->response ) || 'latest' === $core_updates[0]->response || 'development' === $core_updates[0]->response || version_compare( $core_updates[0]->current, $cur_wp_version, '=' ) ) {
+	$core_updates = retraceur_get_updates();
+	if ( ! isset( $core_updates[0]['stable'] ) || false === $core_updates[0]['stable'] || version_compare( $core_updates[0]['version'], $cur_r_version, '=' ) ) {
 		$core_update_version = false;
 	} else {
-		$core_update_version = $core_updates[0]->current;
+		$core_update_version = $core_updates[0]['version'];
 	}
 
 	$plugins_count = count( $plugins );
@@ -651,12 +327,12 @@ function list_plugin_updates() {
 		}
 
 		// Get plugin compat for running version of Retraceur.
-		if ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $cur_wp_version, '>=' ) ) {
+		if ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $cur_r_version, '>=' ) ) {
 			/* translators: %s: Retraceur version. */
-			$compat = '<br />' . sprintf( __( 'Compatibility with Retraceur %s: 100%% (according to its author)' ), $cur_wp_version );
+			$compat = '<br />' . sprintf( __( 'Compatibility with Retraceur %s: 100%% (according to its author)' ), $cur_r_version );
 		} else {
 			/* translators: %s: Retraceur version. */
-			$compat = '<br />' . sprintf( __( 'Compatibility with Retraceur %s: Unknown' ), $cur_wp_version );
+			$compat = '<br />' . sprintf( __( 'Compatibility with Retraceur %s: Unknown' ), $cur_r_version );
 		}
 		// Get plugin compat for updated version of Retraceur.
 		if ( $core_update_version ) {
@@ -1027,25 +703,6 @@ function do_core_upgrade( $reinstall = false ) {
 /**
  * Dismiss a core update.
  *
- * @since WP 2.7.0
- *
- * @todo deprecate
- */
-function do_dismiss_core_update() {
-	$version = isset( $_POST['version'] ) ? $_POST['version'] : false;
-	$locale  = isset( $_POST['locale'] ) ? $_POST['locale'] : 'en_US';
-	$update  = find_core_update( $version, $locale );
-	if ( ! $update ) {
-		return;
-	}
-	dismiss_core_update( $update );
-	wp_redirect( wp_nonce_url( 'update-core.php?action=upgrade-core', 'upgrade-core' ) );
-	exit;
-}
-
-/**
- * Dismiss a core update.
- *
  * @since 2.0.0 Retraceur fork.
  */
 function do_dismiss_coeur_update() {
@@ -1067,25 +724,6 @@ function do_dismiss_coeur_update() {
 	dismiss_coeur_update( $update );
 
 	wp_safe_redirect( wp_nonce_url( 'update-core.php?action=upgrade-core', 'upgrade-core' ) );
-	exit;
-}
-
-/**
- * Undismiss a core update.
- *
- * @since WP 2.7.0
- *
- * @todo deprecate
- */
-function do_undismiss_core_update() {
-	$version = isset( $_POST['version'] ) ? $_POST['version'] : false;
-	$locale  = isset( $_POST['locale'] ) ? $_POST['locale'] : 'en_US';
-	$update  = find_core_update( $version, $locale );
-	if ( ! $update ) {
-		return;
-	}
-	undismiss_core_update( $version, $locale );
-	wp_redirect( wp_nonce_url( 'update-core.php?action=upgrade-core', 'upgrade-core' ) );
 	exit;
 }
 
@@ -1203,7 +841,7 @@ if ( 'upgrade-core' === $action ) {
 	*/
 
 	$last_update_check = false;
-	$current           = get_site_transient( 'retraceur_coeur' );
+	$current           = get_site_transient( 'update_coeur' );
 
 	if ( $current && isset( $current->last_checked ) ) {
 		$last_update_check = $current->last_checked + (int) ( (float) get_option( 'gmt_offset' ) * HOUR_IN_SECONDS );
@@ -1411,28 +1049,6 @@ if ( 'upgrade-core' === $action ) {
 
 	require_once ABSPATH . 'wp-admin/admin-footer.php';
 
-} elseif ( 'core-major-auto-updates-settings' === $action ) {
-
-	if ( ! current_user_can( 'update_core' ) ) {
-		wp_die( __( 'Sorry, you are not allowed to update this site.' ) );
-	}
-
-	$redirect_url = self_admin_url( 'update-core.php' );
-
-	if ( isset( $_GET['value'] ) ) {
-		check_admin_referer( 'core-major-auto-updates-nonce' );
-
-		if ( 'enable' === $_GET['value'] ) {
-			update_site_option( 'auto_update_core_major', 'enabled' );
-			$redirect_url = add_query_arg( 'core-major-auto-updates-saved', 'enabled', $redirect_url );
-		} elseif ( 'disable' === $_GET['value'] ) {
-			update_site_option( 'auto_update_core_major', 'disabled' );
-			$redirect_url = add_query_arg( 'core-major-auto-updates-saved', 'disabled', $redirect_url );
-		}
-	}
-
-	wp_redirect( $redirect_url );
-	exit;
 } else {
 	/**
 	 * Fires for each custom update action on the Retraceur Updates screen.

--- a/wp-admin/update-core.php
+++ b/wp-admin/update-core.php
@@ -1005,23 +1005,20 @@ if ( 'upgrade-core' === $action ) {
 			}
 		}
 	}
+	*/
 
 	$last_update_check = false;
-	$current           = get_site_transient( 'update_core' );
+	$current           = get_site_transient( 'retraceur_coeur' );
 
 	if ( $current && isset( $current->last_checked ) ) {
 		$last_update_check = $current->last_checked + (int) ( (float) get_option( 'gmt_offset' ) * HOUR_IN_SECONDS );
 	}
-	*/
+
 	echo '<h2 class="wp-current-version">';
 	/* translators: Current version of Retraceur. */
 	printf( __( 'Current version: %s' ), esc_html( retraceur_get_version() ) );
 	echo '</h2>';
 
-	/*
-	 * Disable this for now.
-	 * @todo Restore when the Retraceur Update API will be ready.
-	 *
 	echo '<p class="update-last-checked">';
 
 	printf(
@@ -1034,7 +1031,6 @@ if ( 'upgrade-core' === $action ) {
 	);
 	echo ' <a href="' . esc_url( self_admin_url( 'update-core.php?force-check=1' ) ) . '">' . __( 'Check again.' ) . '</a>';
 	echo '</p>';
-	*/
 
 	if ( current_user_can( 'update_core' ) ) {
 		core_auto_updates_settings();

--- a/wp-admin/update-core.php
+++ b/wp-admin/update-core.php
@@ -289,9 +289,10 @@ function list_core_update( $update ) {
  * Display dismissed updates.
  *
  * @since WP 2.7.0
+ * @since 2.0.0 Retraceur fork. Now uses `retraceur_get_updates()`.
  */
 function dismissed_updates() {
-	$dismissed = get_core_updates(
+	$dismissed = retraceur_get_updates(
 		array(
 			'dismissed' => true,
 			'available' => false,
@@ -1027,6 +1028,8 @@ function do_core_upgrade( $reinstall = false ) {
  * Dismiss a core update.
  *
  * @since WP 2.7.0
+ *
+ * @todo deprecate
  */
 function do_dismiss_core_update() {
 	$version = isset( $_POST['version'] ) ? $_POST['version'] : false;
@@ -1041,9 +1044,38 @@ function do_dismiss_core_update() {
 }
 
 /**
+ * Dismiss a core update.
+ *
+ * @since 2.0.0 Retraceur fork.
+ */
+function do_dismiss_coeur_update() {
+	$version = isset( $_POST['version'] ) ? $_POST['version'] : false;
+	$locale  = isset( $_POST['locale'] ) ? $_POST['locale'] : 'en_US';
+	$update  = retraceur_find_coeur_update(
+		$version,
+		$locale,
+		array(
+			'available' => true,
+			'dismissed' => false,
+		),
+	);
+
+	if ( ! $update ) {
+		return;
+	}
+
+	dismiss_coeur_update( $update );
+
+	wp_safe_redirect( wp_nonce_url( 'update-core.php?action=upgrade-core', 'upgrade-core' ) );
+	exit;
+}
+
+/**
  * Undismiss a core update.
  *
  * @since WP 2.7.0
+ *
+ * @todo deprecate
  */
 function do_undismiss_core_update() {
 	$version = isset( $_POST['version'] ) ? $_POST['version'] : false;
@@ -1054,6 +1086,33 @@ function do_undismiss_core_update() {
 	}
 	undismiss_core_update( $version, $locale );
 	wp_redirect( wp_nonce_url( 'update-core.php?action=upgrade-core', 'upgrade-core' ) );
+	exit;
+}
+
+/**
+ * Undismiss a coeur update.
+ *
+ * @since 2.0.0 Retraceur fork.
+ */
+function do_undismiss_coeur_update() {
+	$version = isset( $_POST['version'] ) ? $_POST['version'] : false;
+	$locale  = isset( $_POST['locale'] ) ? $_POST['locale'] : 'en_US';
+	$update  = retraceur_find_coeur_update(
+		$version,
+		$locale,
+		array(
+			'available' => false,
+			'dismissed' => true,
+		),
+	);
+
+	if ( ! $update ) {
+		return;
+	}
+
+	undismiss_coeur_update( $version );
+
+	wp_safe_redirect( wp_nonce_url( 'update-core.php?action=upgrade-core', 'upgrade-core' ) );
 	exit;
 }
 
@@ -1215,9 +1274,9 @@ if ( 'upgrade-core' === $action ) {
 
 	// Do the (un)dismiss actions before headers, so that they can redirect.
 	if ( isset( $_POST['dismiss'] ) ) {
-		do_dismiss_core_update();
+		do_dismiss_coeur_update();
 	} elseif ( isset( $_POST['undismiss'] ) ) {
-		do_undismiss_core_update();
+		do_undismiss_coeur_update();
 	}
 
 	require_once ABSPATH . 'wp-admin/admin-header.php';

--- a/wp-admin/update-core.php
+++ b/wp-admin/update-core.php
@@ -32,7 +32,7 @@ if ( ! current_user_can( 'update_core' ) && ! current_user_can( 'update_themes' 
  *
  * @global wpdb $wpdb Retraceur database abstraction object.
  *
- * @param array $update
+ * @param array $update The retraceur update informations.
  */
 function retraceur_list_update( $update ) {
 	global $wpdb;
@@ -116,6 +116,7 @@ function retraceur_list_update( $update ) {
 
 	echo '<p>';
 	echo '<input name="version" value="' . esc_attr( $update['version'] ) . '" type="hidden" />';
+	echo '<input name="locale" value="' . esc_attr( $update['locale'] ) . '" type="hidden" />';
 	if ( $show_buttons ) {
 		if ( $first_pass ) {
 			submit_button( $submit, $current ? '' : 'primary regular', 'upgrade', false );
@@ -371,8 +372,13 @@ function core_upgrade_preamble() {
 	}
 
 	echo '<ul class="core-updates">';
+
 	foreach ( (array) $updates as $update ) {
-		// Disable older stable version than current.
+		if ( true !== $update['stable'] && ! $is_development_version ) {
+			continue;
+		}
+
+		// Disable older version than current.
 		if ( version_compare( $update['version'], $retraceur_version, '<=' ) ) {
 			continue;
 		}
@@ -926,9 +932,15 @@ function do_core_upgrade( $reinstall = false ) {
 
 	$version = isset( $_POST['version'] ) ? $_POST['version'] : false;
 	$locale  = isset( $_POST['locale'] ) ? $_POST['locale'] : 'en_US';
-	$update  = find_core_update( $version, $locale );
+	$update  = retraceur_find_coeur_update( $version, $locale );
 	if ( ! $update ) {
 		return;
+	} else {
+		$update           = (object) $update;
+		$update->response = 'upgrade';
+
+		// For now consider each update contains new files.
+		$update->new_files = true;
 	}
 
 	/*
@@ -939,7 +951,7 @@ function do_core_upgrade( $reinstall = false ) {
 
 	?>
 	<div class="wrap">
-	<h1><?php _e( 'Update Retraceur' ); ?></h1>
+	<h1><?php esc_html_e( 'Update Retraceur' ); ?></h1>
 	<?php
 
 	$credentials = request_filesystem_credentials( $url, '', false, ABSPATH, array( 'version', 'locale' ), $allow_relaxed_file_ownership );

--- a/wp-admin/update-core.php
+++ b/wp-admin/update-core.php
@@ -968,7 +968,7 @@ get_current_screen()->add_help_tab(
 if ( 'upgrade-core' === $action ) {
 	// Force an update check when requested.
 	$force_check = ! empty( $_GET['force-check'] );
-	wp_version_check( array(), $force_check );
+	retraceur_version_check( $force_check );
 
 	require_once ABSPATH . 'wp-admin/admin-header.php';
 	?>

--- a/wp-admin/upgrade.php
+++ b/wp-admin/upgrade.php
@@ -23,7 +23,7 @@ nocache_headers();
 
 require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
-delete_site_transient( 'update_core' );
+delete_site_transient( 'update_coeur' );
 
 if ( isset( $_GET['step'] ) ) {
 	$step = $_GET['step'];

--- a/wp-includes/class-wp-feed-cache-version-check.php
+++ b/wp-includes/class-wp-feed-cache-version-check.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Feed API: class to avoid a SimplePie warning about the cache location.
+ *
+ * @since 2.0.0 Retraceur fork.
+ *
+ * @package Retraceur
+ */
+
+/**
+ * Core class to avoid a SimplePie warning about the cache location.
+ *
+ * @since 2.0.0 Retraceur fork.
+ */
+#[AllowDynamicProperties]
+class WP_Feed_Cache_Version_Check implements SimplePie\Cache\Base {
+
+	/**
+	 * Creates a new cache object.
+	 *
+	 * @since 2.0.0 Retraceur fork.
+	 *
+	 * @param string                           $location URL location (scheme is used to determine handler).
+	 * @param string                           $name     Unique identifier for cache object.
+	 * @param Base::TYPE_FEED|Base::TYPE_IMAGE $type     Either `TYPE_FEED` ('spc') for SimplePie data,
+	 *                                                   or `TYPE_IMAGE` ('spi') for image data.
+	 */
+	public function __construct( $location, $name, $type ) { /* Do nothing. */ }
+
+	/**
+	 * Saves data to the transient.
+	 *
+	 * @since 2.0.0 Retraceur fork.
+	 *
+	 * @param array|SimplePie\SimplePie $data Data to save. If passed a SimplePie object,
+	 *                                        only cache the `$data` property.
+	 * @return true Always true.
+	 */
+	public function save( $data ) {
+		return true;
+	}
+
+	/**
+	 * Retrieves the data saved in the transient.
+	 *
+	 * @since 2.0.0 Retraceur fork.
+	 *
+	 * @return array Data for `SimplePie::$data`.
+	 */
+	public function load() {
+		return array();
+	}
+
+	/**
+	 * Gets mod transient.
+	 *
+	 * @since 2.0.0 Retraceur fork.
+	 *
+	 * @return int Timestamp.
+	 */
+	public function mtime() {
+		return time();
+	}
+
+	/**
+	 * Sets mod cache.
+	 *
+	 * @since 2.0.0 Retraceur fork.
+	 *
+	 * @return true Always true.
+	 */
+	public function touch() {
+		return true;
+	}
+
+	/**
+	 * Deletes cache.
+	 *
+	 * @since 2.0.0 Retraceur fork.
+	 *
+	 * @return true Always true.
+	 */
+	public function unlink() {
+		return true;
+	}
+}

--- a/wp-includes/deprecated.php
+++ b/wp-includes/deprecated.php
@@ -16490,7 +16490,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 		array( array() ),
 		'2.0.0',
 		'',
-		__( 'The WP Auto Updates feature is not used by Retraceur fork.' )
+		__( 'The WP Background Updates feature is not used by Retraceur fork.' )
 	);
 
 	return;

--- a/wp-includes/deprecated.php
+++ b/wp-includes/deprecated.php
@@ -16495,3 +16495,17 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 
 	return;
 }
+
+/**
+ * Performs WP automatic background updates.
+ *
+ * Updates WP core plus any plugins and themes that have automatic updates enabled.
+ *
+ * @since WP 3.7.0
+ * @since 1.0.0 Retraceur fork.
+ * @deprecated 2.0.0 Retraceur fork.
+ */
+function wp_maybe_auto_update() {
+	_deprecated_function( __FUNCTION__, '2.0.0', '', true );
+	return;
+}

--- a/wp-includes/deprecated.php
+++ b/wp-includes/deprecated.php
@@ -16446,3 +16446,52 @@ function _post_format_request( $qvs ) {
 	_deprecated_function( __FUNCTION__, '2.0.0', '', true );
 	return $qvs;
 }
+
+/**
+ * Checks Retraceur version against the newest version.
+ *
+ * The Retraceur version, PHP version, and locale is sent to remote directory provider.
+ *
+ * @since WP 2.3.0
+ * @since 1.0.0 Retraceur fork.
+ * @deprecated 2.0.0 Retraceur fork.
+ *
+ * @global string $retraceur_version       Used to check against the newest Retraceur version.
+ * @global wpdb   $wpdb             WP database abstraction object.
+ * @global string $wp_local_package Locale code of the package.
+ *
+ * @param array $extra_stats Extra statistics.
+ * @param bool  $force_check Whether to bypass the transient cache and force a fresh update check.
+ *                           Defaults to false, true if $extra_stats is set.
+ */
+function wp_version_check( $extra_stats = array(), $force_check = false ) {
+	_deprecated_function( __FUNCTION__, '2.0.0', '', true );
+
+	/**
+	 * Filters the query arguments sent as part of the core version check.
+	 *
+	 * WARNING: Changing this data may result in your site not receiving security updates.
+	 * Please exercise extreme caution.
+	 *
+	 * @since WP 4.9.0
+	 * @since WP 6.1.0 Added `$extensions`, `$platform_flags`, and `$image_support` to the `$query` parameter.
+	 * @since 1.0.0 Retraceur fork: remove extra statistics.
+	 * @deprecated 2.0.0 Retraceur fork.
+	 *
+	 * @param array $query {
+	 *     Version check query arguments.
+	 *
+	 *     @type string $version Retraceur version number.
+	 *     @type string $locale  The locale to retrieve updates for.
+	 * }
+	 */
+	apply_filters_deprecated(
+		'core_version_check_query_args',
+		array( array() ),
+		'2.0.0',
+		'',
+		__( 'The WP Auto Updates feature is not used by Retraceur fork.' )
+	);
+
+	return;
+}

--- a/wp-includes/l10n.php
+++ b/wp-includes/l10n.php
@@ -966,7 +966,7 @@ function load_default_textdomain( $locale = null ) {
 		return $return;
 	}
 
-	if ( is_admin() || wp_installing() || ( defined( 'WP_REPAIRING' ) && WP_REPAIRING ) || doing_action( 'wp_maybe_auto_update' ) ) {
+	if ( is_admin() || wp_installing() || ( defined( 'WP_REPAIRING' ) && WP_REPAIRING ) ) {
 		load_textdomain( 'default', WP_LANG_DIR . "/admin-$locale.mo", $locale );
 	}
 

--- a/wp-includes/update.php
+++ b/wp-includes/update.php
@@ -125,6 +125,14 @@ function retraceur_version_check( $force_check = false ) {
 		$locale = 'en_US';
 	}
 
+	/**
+	 * When building the `retraceur-fr_FR.zip` package, it's required that a "retraceur" named folder
+	 * is first compressed to `retraceur.zip` and then renamed as `retraceur-fr_FR.zip`.
+	 */
+	if ( 'fr_FR' === $locale ) {
+		$package = 'retraceur-fr_FR.zip';
+	}
+
 	foreach ( $releases as $release ) {
 		$version    = '';
 		$release_id = explode( '/', rtrim( $release->get_id(), '/' ) );

--- a/wp-includes/update.php
+++ b/wp-includes/update.php
@@ -57,7 +57,7 @@ function retraceur_version_check( $force_check = false ) {
 		return;
 	}
 
-	$current         = get_site_transient( 'retraceur_coeur' );
+	$current         = get_site_transient( 'update_coeur' );
 	$version_checked = retraceur_get_version();
 
 	// Invalidate the transient when $retraceur_version changes.
@@ -80,7 +80,7 @@ function retraceur_version_check( $force_check = false ) {
 	}
 
 	$current->last_checked = time();
-	set_site_transient( 'retraceur_coeur', $current );
+	set_site_transient( 'update_coeur', $current );
 
 	if ( ! class_exists( 'SimplePie\SimplePie', false ) ) {
 		require_once ABSPATH . WPINC . '/class-simplepie.php';
@@ -163,215 +163,9 @@ function retraceur_version_check( $force_check = false ) {
 	$updates->last_checked    = time();
 	$updates->version_checked = $version_checked;
 
-	set_site_transient( 'retraceur_coeur', $updates );
+	set_site_transient( 'update_coeur', $updates );
 
 	return $updates;
-}
-
-/**
- * Checks Retraceur version against the newest version.
- *
- * The Retraceur version, PHP version, and locale is sent to remote directory provider.
- *
- * @since WP 2.3.0
- * @since 1.0.0 Retraceur fork.
- * @todo deprecate
- *
- * @global string $retraceur_version       Used to check against the newest Retraceur version.
- * @global wpdb   $wpdb             WP database abstraction object.
- * @global string $wp_local_package Locale code of the package.
- *
- * @param array $extra_stats Extra statistics.
- * @param bool  $force_check Whether to bypass the transient cache and force a fresh update check.
- *                           Defaults to false, true if $extra_stats is set.
- */
-function wp_version_check( $extra_stats = array(), $force_check = false ) {
-	global $wpdb, $wp_local_package;
-
-	// Disable version checks for now.
-	return;
-
-	if ( wp_installing() ) {
-		return;
-	}
-
-	$current      = get_site_transient( 'update_core' );
-	$translations = wp_get_installed_translations( 'core' );
-
-	// Invalidate the transient when $retraceur_version changes.
-	if ( is_object( $current ) && retraceur_get_version() !== $current->version_checked ) {
-		$current = false;
-	}
-
-	if ( ! is_object( $current ) ) {
-		$current                  = new stdClass();
-		$current->updates         = array();
-		$current->version_checked = retraceur_get_version();
-	}
-
-	if ( ! empty( $extra_stats ) ) {
-		$force_check = true;
-	}
-
-	// Wait 1 minute between multiple version check requests.
-	$timeout          = MINUTE_IN_SECONDS;
-	$time_not_changed = isset( $current->last_checked ) && $timeout > ( time() - $current->last_checked );
-
-	if ( ! $force_check && $time_not_changed ) {
-		return;
-	}
-
-	/**
-	 * Filters the locale requested for WP core translations.
-	 *
-	 * @since WP 2.8.0
-	 *
-	 * @param string $locale Current locale.
-	 */
-	$locale = apply_filters( 'core_version_check_locale', get_locale() );
-
-	// Update last_checked for current to prevent multiple blocking requests if request hangs.
-	$current->last_checked = time();
-	set_site_transient( 'update_core', $current );
-
-	$query = array(
-		'version' => retraceur_get_version(),
-		'locale'  => $locale,
-	);
-
-	/**
-	 * Filters the query arguments sent as part of the core version check.
-	 *
-	 * WARNING: Changing this data may result in your site not receiving security updates.
-	 * Please exercise extreme caution.
-	 *
-	 * @since WP 4.9.0
-	 * @since WP 6.1.0 Added `$extensions`, `$platform_flags`, and `$image_support` to the `$query` parameter.
-	 * @since 1.0.0 Retraceur fork: remove extra statistics.
-	 *
-	 * @param array $query {
-	 *     Version check query arguments.
-	 *
-	 *     @type string $version Retraceur version number.
-	 *     @type string $locale  The locale to retrieve updates for.
-	 * }
-	 */
-	$query = apply_filters( 'core_version_check_query_args', $query );
-
-	$post_body = array(
-		'translations' => wp_json_encode( $translations ),
-	);
-
-	// @todo See what's doable using GitHub.
-	$url      = '';
-	$http_url = $url;
-	$ssl      = wp_http_supports( array( 'ssl' ) );
-
-	if ( $ssl ) {
-		$url = set_url_scheme( $url, 'https' );
-	}
-
-	$doing_cron = wp_doing_cron();
-
-	$options = array(
-		'timeout'    => $doing_cron ? 30 : 3,
-		'user-agent' => 'Retraceur/' . retraceur_get_version() . '; ' . home_url( '/' ),
-		'headers'    => array(
-			'wp_install' => $wp_install,
-			'wp_blog'    => home_url( '/' ),
-		),
-		'body'       => $post_body,
-	);
-
-	$response = wp_remote_post( $url, $options );
-
-	if ( $ssl && is_wp_error( $response ) ) {
-		wp_trigger_error(
-			__FUNCTION__,
-			__( 'An unexpected error occurred. Something may be wrong with this server&#8217;s configuration.' ) . ' ' . __( '(Retraceur could not establish a secure connection to Core Updater. Please contact your server administrator.)' ),
-			headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
-		);
-		$response = wp_remote_post( $http_url, $options );
-	}
-
-	if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-		return;
-	}
-
-	$body = trim( wp_remote_retrieve_body( $response ) );
-	$body = json_decode( $body, true );
-
-	if ( ! is_array( $body ) || ! isset( $body['offers'] ) ) {
-		return;
-	}
-
-	$offers = $body['offers'];
-
-	foreach ( $offers as &$offer ) {
-		foreach ( $offer as $offer_key => $value ) {
-			if ( 'packages' === $offer_key ) {
-				$offer['packages'] = (object) array_intersect_key(
-					array_map( 'esc_url', $offer['packages'] ),
-					array_fill_keys( array( 'full', 'no_content', 'new_bundled', 'partial', 'rollback' ), '' )
-				);
-			} elseif ( 'download' === $offer_key ) {
-				$offer['download'] = esc_url( $value );
-			} else {
-				$offer[ $offer_key ] = esc_html( $value );
-			}
-		}
-		$offer = (object) array_intersect_key(
-			$offer,
-			array_fill_keys(
-				array(
-					'response',
-					'download',
-					'locale',
-					'packages',
-					'current',
-					'version',
-					'php_version',
-					'mysql_version',
-					'new_bundled',
-					'partial_version',
-					'notify_email',
-					'support_email',
-					'new_files',
-				),
-				''
-			)
-		);
-	}
-
-	$updates                  = new stdClass();
-	$updates->updates         = $offers;
-	$updates->last_checked    = time();
-	$updates->version_checked = retraceur_get_version();
-
-	if ( isset( $body['translations'] ) ) {
-		$updates->translations = $body['translations'];
-	}
-
-	set_site_transient( 'update_core', $updates );
-
-	if ( ! empty( $body['ttl'] ) ) {
-		$ttl = (int) $body['ttl'];
-
-		if ( $ttl && ( time() + $ttl < wp_next_scheduled( 'wp_version_check' ) ) ) {
-			// Queue an event to re-run the update check in $ttl seconds.
-			wp_schedule_single_event( time() + $ttl, 'wp_version_check' );
-		}
-	}
-
-	// Trigger background updates if running non-interactively, and we weren't called from the update handler.
-	if ( $doing_cron && ! doing_action( 'wp_maybe_auto_update' ) ) {
-		/**
-		 * Fires during wp_cron, starting the auto-update process.
-		 *
-		 * @since WP 3.9.0
-		 */
-		do_action( 'wp_maybe_auto_update' );
-	}
 }
 
 /**
@@ -936,7 +730,7 @@ function wp_get_translation_updates() {
 
 	$updates    = array();
 	$transients = array(
-		'update_core'    => 'core',
+		'update_coeur'    => 'core',
 		'update_plugins' => 'plugin',
 		'update_themes'  => 'theme',
 	);
@@ -1014,11 +808,11 @@ function wp_get_update_data() {
 
 	$core = current_user_can( 'update_core' );
 
-	if ( $core && function_exists( 'get_core_updates' ) ) {
-		$update_retraceur = get_core_updates( array( 'dismissed' => false ) );
+	if ( $core && function_exists( 'retraceur_get_updates' ) ) {
+		$update_retraceur = retraceur_get_updates( array( 'dismissed' => false ) );
 
 		if ( ! empty( $update_retraceur )
-			&& ! in_array( $update_retraceur[0]->response, array( 'development', 'latest' ), true )
+			&& true === $update_retraceur[0]['stable']
 			&& current_user_can( 'update_core' )
 		) {
 			$counts['retraceur'] = 1;
@@ -1079,7 +873,7 @@ function wp_get_update_data() {
  * @since WP 2.8.0
  */
 function _maybe_update_core() {
-	$current = get_site_transient( 'update_core' );
+	$current = get_site_transient( 'update_coeur' );
 
 	if ( isset( $current->last_checked, $current->version_checked )
 		&& 12 * HOUR_IN_SECONDS > ( time() - $current->last_checked )
@@ -1088,7 +882,7 @@ function _maybe_update_core() {
 		return;
 	}
 
-	wp_version_check();
+	retraceur_version_check();
 }
 /**
  * Checks the last time plugins were run before checking plugin versions.
@@ -1139,8 +933,8 @@ function _maybe_update_themes() {
  * @since WP 3.1.0
  */
 function wp_schedule_update_checks() {
-	if ( ! wp_next_scheduled( 'wp_version_check' ) && ! wp_installing() ) {
-		wp_schedule_event( time(), 'twicedaily', 'wp_version_check' );
+	if ( ! wp_next_scheduled( 'retraceur_version_check' ) && ! wp_installing() ) {
+		wp_schedule_event( time(), 'twicedaily', 'retraceur_version_check' );
 	}
 
 	if ( ! wp_next_scheduled( 'wp_update_plugins' ) && ! wp_installing() ) {
@@ -1166,7 +960,7 @@ function wp_clean_update_cache() {
 
 	wp_clean_themes_cache();
 
-	delete_site_transient( 'update_core' );
+	delete_site_transient( 'update_coeur' );
 }
 
 /**
@@ -1245,10 +1039,11 @@ if ( ( ! is_main_site() && ! is_network_admin() ) || wp_doing_ajax() ) {
  *
  * @since 1.0.0 Retraceur fork.
  */
-/*add_action( 'admin_init', '_maybe_update_core' );
-add_action( 'wp_version_check', 'wp_version_check' );
+//add_action( 'admin_init', '_maybe_update_core' );
+add_action( 'retraceur_version_check', 'retraceur_version_check' );
+add_action( 'init', 'wp_schedule_update_checks' );
 
-add_action( 'load-plugins.php', 'wp_update_plugins' );
+/*add_action( 'load-plugins.php', 'wp_update_plugins' );
 add_action( 'load-update.php', 'wp_update_plugins' );
 add_action( 'load-update-core.php', 'wp_update_plugins' );
 add_action( 'admin_init', '_maybe_update_plugins' );
@@ -1263,7 +1058,5 @@ add_action( 'wp_update_themes', 'wp_update_themes' );
 add_action( 'update_option_WPLANG', 'wp_clean_update_cache', 10, 0 );
 
 add_action( 'wp_maybe_auto_update', 'wp_maybe_auto_update' );
-
-add_action( 'init', 'wp_schedule_update_checks' );
 
 add_action( 'wp_delete_temp_updater_backups', 'wp_delete_all_temp_backups' );*/

--- a/wp-includes/update.php
+++ b/wp-includes/update.php
@@ -118,6 +118,16 @@ function retraceur_version_check( $force_check = false ) {
 
 	$releases = $feed->get_items();
 	$offers   = array();
+	$locale   = get_locale();
+	$package  = 'retraceur.zip';
+
+	if ( ! $locale ) {
+		$locale = 'en_US';
+	}
+
+	if ( 'fr_FR' === $locale ) {
+		$package  = 'retraceur-fr_FR.zip';
+	}
 
 	foreach ( $releases as $release ) {
 		$version    = '';
@@ -141,12 +151,14 @@ function retraceur_version_check( $force_check = false ) {
 		$offers[] = array(
 			'version'      => $version,
 			'url'          => $url,
+			'download'     => trailingslashit( str_replace( 'tag', 'download', $url ) ) . $package,
 			'requirements' => array(
 				'php'   => strip_tags( $needs_php ),
 				'mysql' => strip_tags( $needs_mysql ),
 			),
 			'date'         => $release->get_date( 'U' ),
 			'stable'       => $is_stable,
+			'locale'       => $locale,
 		);
 	}
 
@@ -154,7 +166,6 @@ function retraceur_version_check( $force_check = false ) {
 	$updates->updates         = $offers;
 	$updates->last_checked    = time();
 	$updates->version_checked = $version_checked;
-	$updates->locale          = get_locale();
 
 	set_site_transient( 'retraceur_coeur', $updates );
 

--- a/wp-includes/update.php
+++ b/wp-includes/update.php
@@ -125,10 +125,6 @@ function retraceur_version_check( $force_check = false ) {
 		$locale = 'en_US';
 	}
 
-	if ( 'fr_FR' === $locale ) {
-		$package  = 'retraceur-fr_FR.zip';
-	}
-
 	foreach ( $releases as $release ) {
 		$version    = '';
 		$release_id = explode( '/', rtrim( $release->get_id(), '/' ) );

--- a/wp-includes/update.php
+++ b/wp-includes/update.php
@@ -40,8 +40,8 @@ function retraceur_version_check( $force_check = false ) {
 		$current->version_checked = retraceur_get_version();
 	}
 
-	// Wait 1 minute between multiple version check requests.
-	$timeout          = MINUTE_IN_SECONDS;
+	// Wait 1 day between multiple version check requests.
+	$timeout          = DAY_IN_SECONDS;
 	$time_not_changed = isset( $current->last_checked ) && $timeout > ( time() - $current->last_checked );
 
 	if ( ! $force_check && $time_not_changed ) {
@@ -99,14 +99,17 @@ function retraceur_version_check( $force_check = false ) {
 			$version  = end( $url_data );
 		}
 
-		if ( ! $version ) {
+		if ( ! $version || version_compare( $version, retraceur_get_version(), '<=' ) ) {
 			continue;
 		}
+
+		$is_stable = is_numeric( str_replace( '.', '', $version ) );
 
 		$offers[] = array(
 			'version' => $version,
 			'url'     => $url,
 			'date'    => $release->get_date( 'U' ),
+			'stable'  => $is_stable,
 		);
 	}
 
@@ -114,6 +117,7 @@ function retraceur_version_check( $force_check = false ) {
 	$updates->updates         = $offers;
 	$updates->last_checked    = time();
 	$updates->version_checked = retraceur_get_version();
+	$updates->locale          = get_locale();
 
 	set_site_transient( 'retraceur_coeur', $updates );
 

--- a/wp-includes/update.php
+++ b/wp-includes/update.php
@@ -698,25 +698,6 @@ function wp_update_themes( $extra_stats = array() ) {
 }
 
 /**
- * Performs WP automatic background updates.
- *
- * Updates WP core plus any plugins and themes that have automatic updates enabled.
- *
- * @since WP 3.7.0
- * @since 1.0.0 Retraceur fork.
- */
-function wp_maybe_auto_update() {
-	// Disable auto updates for now.
-	return;
-
-	require_once ABSPATH . 'wp-admin/includes/admin.php';
-	require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
-
-	$upgrader = new WP_Automatic_Updater();
-	$upgrader->run();
-}
-
-/**
  * Retrieves a list of all language updates available.
  *
  * @since WP 3.7.0
@@ -758,12 +739,20 @@ function wp_get_translation_updates() {
  * @return boolean True if the Automatic Updater is enabled. False otherwise.
  */
 function retraceur_is_updater_enabled() {
-	if ( ! class_exists( 'WP_Automatic_Updater' ) ) {
-		require_once ABSPATH . 'wp-admin/includes/class-wp-automatic-updater.php';
+	$enabled = true;
+
+	if ( ! wp_is_file_mod_allowed( 'retraceur_updater' ) || wp_installing() ) {
+		$enabled = false;
 	}
 
-	$updater = new WP_Automatic_Updater();
-	return ! $updater->is_disabled();
+	/**
+	 * Filters whether to entirely disable the Retraceur updater.
+	 *
+	 * @since 2.0.0 Retraceur fork.
+	 *
+	 * @param boolean $enabled True if enabled. False otherwise.
+	 */
+	return apply_filters( 'retraceur_is_updater_enabled', $enabled );
 }
 
 /**
@@ -1056,7 +1045,5 @@ add_action( 'admin_init', '_maybe_update_themes' );
 add_action( 'wp_update_themes', 'wp_update_themes' );
 
 add_action( 'update_option_WPLANG', 'wp_clean_update_cache', 10, 0 );
-
-add_action( 'wp_maybe_auto_update', 'wp_maybe_auto_update' );
 
 add_action( 'wp_delete_temp_updater_backups', 'wp_delete_all_temp_backups' );*/

--- a/wp-includes/update.php
+++ b/wp-includes/update.php
@@ -118,7 +118,7 @@ function retraceur_version_check( $force_check = false ) {
 
 	$releases = $feed->get_items();
 	$offers   = array();
-	$locale   = get_locale();
+	$locale   = get_option( 'WPLANG' );
 	$package  = 'retraceur.zip';
 
 	if ( ! $locale ) {

--- a/wp-includes/update.php
+++ b/wp-includes/update.php
@@ -14,6 +14,36 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Look for Retraceur requirements parsing its release note content.
+ *
+ * @since 2.0.0 Retraceur fork.
+ *
+ * @param string $html HTML content of the release note.
+ * @param string $type 'PHP' or 'MySQL'.
+ * @return string The required version number.
+ */
+function retraceur_get_requirement( $html, $type = 'PHP' ) {
+	$tags    = new WP_HTML_Tag_Processor( $html );
+	$tag     = 'MySQL' === $type ? 'td' : 'th';
+	$skip    = $type . ' >=';
+	$version = '';
+	$i       = 2;
+
+	while ( $i > 0 && $tags->next_tag( $tag ) ) {
+		$tags->next_token();
+
+		$version = $tags->get_modifiable_text();
+		if ( $skip === $version ) {
+			$version ='';
+		}
+
+		$i--;
+	}
+
+	return $version;
+}
+
+/**
  * Checks if a Retraceur update is available.
  *
  * @since 2.0.0 Retraceur fork.
@@ -27,17 +57,18 @@ function retraceur_version_check( $force_check = false ) {
 		return;
 	}
 
-	$current = get_site_transient( 'retraceur_coeur' );
+	$current         = get_site_transient( 'retraceur_coeur' );
+	$version_checked = retraceur_get_version();
 
 	// Invalidate the transient when $retraceur_version changes.
-	if ( is_object( $current ) && retraceur_get_version() !== $current->version_checked ) {
+	if ( is_object( $current ) && $version_checked !== $current->version_checked ) {
 		$current = false;
 	}
 
 	if ( ! is_object( $current ) ) {
 		$current                  = new stdClass();
 		$current->updates         = array();
-		$current->version_checked = retraceur_get_version();
+		$current->version_checked = $version_checked;
 	}
 
 	// Wait 1 day between multiple version check requests.
@@ -99,24 +130,30 @@ function retraceur_version_check( $force_check = false ) {
 			$version  = end( $url_data );
 		}
 
-		if ( ! $version || version_compare( $version, retraceur_get_version(), '<=' ) ) {
+		if ( ! $version || version_compare( $version, $version_checked, '<=' ) ) {
 			continue;
 		}
 
-		$is_stable = is_numeric( str_replace( '.', '', $version ) );
+		$is_stable   = is_numeric( str_replace( '.', '', $version ) );
+		$needs_php   = retraceur_get_requirement( $release->get_description() );
+		$needs_mysql = retraceur_get_requirement( $release->get_description(), 'MySQL' );
 
 		$offers[] = array(
-			'version' => $version,
-			'url'     => $url,
-			'date'    => $release->get_date( 'U' ),
-			'stable'  => $is_stable,
+			'version'      => $version,
+			'url'          => $url,
+			'requirements' => array(
+				'php'   => strip_tags( $needs_php ),
+				'mysql' => strip_tags( $needs_mysql ),
+			),
+			'date'         => $release->get_date( 'U' ),
+			'stable'       => $is_stable,
 		);
 	}
 
 	$updates                  = new stdClass();
 	$updates->updates         = $offers;
 	$updates->last_checked    = time();
-	$updates->version_checked = retraceur_get_version();
+	$updates->version_checked = $version_checked;
 	$updates->locale          = get_locale();
 
 	set_site_transient( 'retraceur_coeur', $updates );
@@ -131,6 +168,7 @@ function retraceur_version_check( $force_check = false ) {
  *
  * @since WP 2.3.0
  * @since 1.0.0 Retraceur fork.
+ * @todo deprecate
  *
  * @global string $retraceur_version       Used to check against the newest Retraceur version.
  * @global wpdb   $wpdb             WP database abstraction object.

--- a/wp-includes/update.php
+++ b/wp-includes/update.php
@@ -14,6 +14,113 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Checks if a Retraceur update is available.
+ *
+ * @since 2.0.0 Retraceur fork.
+ *
+ * @param bool $force_check Whether to bypass the transient cache and force a fresh update check.
+ *                          Defaults to false, true if $extra_stats is set.
+ * @return object The available updates.
+ */
+function retraceur_version_check( $force_check = false ) {
+	if ( wp_installing() ) {
+		return;
+	}
+
+	$current = get_site_transient( 'retraceur_coeur' );
+
+	// Invalidate the transient when $retraceur_version changes.
+	if ( is_object( $current ) && retraceur_get_version() !== $current->version_checked ) {
+		$current = false;
+	}
+
+	if ( ! is_object( $current ) ) {
+		$current                  = new stdClass();
+		$current->updates         = array();
+		$current->version_checked = retraceur_get_version();
+	}
+
+	// Wait 1 minute between multiple version check requests.
+	$timeout          = MINUTE_IN_SECONDS;
+	$time_not_changed = isset( $current->last_checked ) && $timeout > ( time() - $current->last_checked );
+
+	if ( ! $force_check && $time_not_changed ) {
+		return;
+	}
+
+	$current->last_checked = time();
+	set_site_transient( 'retraceur_coeur', $current );
+
+	if ( ! class_exists( 'SimplePie\SimplePie', false ) ) {
+		require_once ABSPATH . WPINC . '/class-simplepie.php';
+	}
+
+	require_once ABSPATH . WPINC . '/class-wp-simplepie-file.php';
+	require_once ABSPATH . WPINC . '/class-wp-feed-cache-version-check.php';
+	require_once ABSPATH . WPINC . '/class-wp-simplepie-sanitize-kses.php';
+
+	$feed = new SimplePie\SimplePie();
+	$url  = 'https://github.com/retraceur/coeur/releases.atom';
+
+	$feed->set_sanitize_class( 'WP_SimplePie_Sanitize_KSES' );
+	/*
+	 * We must manually overwrite $feed->sanitize because SimplePie's constructor
+	 * sets it before we have a chance to set the sanitization class.
+	 */
+	$feed->sanitize = new WP_SimplePie_Sanitize_KSES();
+
+	// Register the cache handler using the recommended method for SimplePie 1.3 or later.
+	if ( method_exists( 'SimplePie_Cache', 'register' ) ) {
+		SimplePie_Cache::register( 'retraceur_coeur_update', 'WP_Feed_Cache_Version_Check' );
+		$feed->set_cache_location( 'retraceur_coeur_update' );
+	}
+
+	$feed->set_file_class( 'WP_SimplePie_File' );
+
+	$feed->set_feed_url( $url );
+	$feed->init();
+	$feed->set_output_encoding( get_bloginfo( 'charset' ) );
+
+	if ( $feed->error() ) {
+		return new WP_Error( 'simplepie-error', $feed->error() );
+	}
+
+	$releases = $feed->get_items();
+	$offers   = array();
+
+	foreach ( $releases as $release ) {
+		$version    = '';
+		$release_id = explode( '/', rtrim( $release->get_id(), '/' ) );
+		$version    = end( $release_id );
+		$url        = $release->get_link();
+
+		if ( ! $version ) {
+			$url_data = explode( '/', rtrim( wp_parse_url( $url, PHP_URL_PATH ) ) );
+			$version  = end( $url_data );
+		}
+
+		if ( ! $version ) {
+			continue;
+		}
+
+		$offers[] = array(
+			'version' => $version,
+			'url'     => $url,
+			'date'    => $release->get_date( 'U' ),
+		);
+	}
+
+	$updates                  = new stdClass();
+	$updates->updates         = $offers;
+	$updates->last_checked    = time();
+	$updates->version_checked = retraceur_get_version();
+
+	set_site_transient( 'retraceur_coeur', $updates );
+
+	return $updates;
+}
+
+/**
  * Checks Retraceur version against the newest version.
  *
  * The Retraceur version, PHP version, and locale is sent to remote directory provider.

--- a/wp-includes/update.php
+++ b/wp-includes/update.php
@@ -711,7 +711,7 @@ function wp_get_translation_updates() {
 
 	$updates    = array();
 	$transients = array(
-		'update_coeur'    => 'core',
+		'update_coeur'   => 'core',
 		'update_plugins' => 'plugin',
 		'update_themes'  => 'theme',
 	);
@@ -926,13 +926,18 @@ function wp_schedule_update_checks() {
 		wp_schedule_event( time(), 'twicedaily', 'retraceur_version_check' );
 	}
 
-	if ( ! wp_next_scheduled( 'wp_update_plugins' ) && ! wp_installing() ) {
+	/**
+	 * Disable Plugin and Theme new update checks for now.
+	 *
+	 * @todo Restore it once adaptations to Retraceur fork are put in place.
+	 */
+	/*if ( ! wp_next_scheduled( 'wp_update_plugins' ) && ! wp_installing() ) {
 		wp_schedule_event( time(), 'twicedaily', 'wp_update_plugins' );
 	}
 
 	if ( ! wp_next_scheduled( 'wp_update_themes' ) && ! wp_installing() ) {
 		wp_schedule_event( time(), 'twicedaily', 'wp_update_themes' );
-	}
+	}*/
 }
 
 /**
@@ -1028,7 +1033,7 @@ if ( ( ! is_main_site() && ! is_network_admin() ) || wp_doing_ajax() ) {
  *
  * @since 1.0.0 Retraceur fork.
  */
-//add_action( 'admin_init', '_maybe_update_core' );
+add_action( 'admin_init', '_maybe_update_core' );
 add_action( 'retraceur_version_check', 'retraceur_version_check' );
 add_action( 'init', 'wp_schedule_update_checks' );
 
@@ -1045,5 +1050,6 @@ add_action( 'admin_init', '_maybe_update_themes' );
 add_action( 'wp_update_themes', 'wp_update_themes' );
 
 add_action( 'update_option_WPLANG', 'wp_clean_update_cache', 10, 0 );
+*/
 
-add_action( 'wp_delete_temp_updater_backups', 'wp_delete_all_temp_backups' );*/
+add_action( 'wp_delete_temp_updater_backups', 'wp_delete_all_temp_backups' );

--- a/wp-includes/update.php
+++ b/wp-includes/update.php
@@ -34,7 +34,7 @@ function retraceur_get_requirement( $html, $type = 'PHP' ) {
 
 		$version = $tags->get_modifiable_text();
 		if ( $skip === $version ) {
-			$version ='';
+			$version = '';
 		}
 
 		$i--;

--- a/wp-includes/version.php
+++ b/wp-includes/version.php
@@ -34,7 +34,7 @@ $retraceur_version = '2.0.0-alpha';
  *
  * @global int $wp_db_version
  */
-$wp_db_version = 20250621;
+$wp_db_version = 20250711;
 
 /**
  * Holds the TinyMCE version.


### PR DESCRIPTION
- Adapt WP functions to communicate with GitHub releases to check for, download & upgrade to new versions.
- Adapt Site Health info and debug tools.
- Introduce new Retraceur functions and options to store versions checks and dismissed updates.
- Deprecate WP functions/methods about "background" updates.
- Neutralize WP Plugin, Theme and translation update APIs.
- Put the new Retraceur Coeur Update API behind a filter to let users opt-in to it.
- Add a link to download and manually upgrade new releases.

See #30 