### PR TITLE
Make sure the "core/more" block is honored by the Site Editor

### DIFF
--- a/wp-content/themes/point/functions.php
+++ b/wp-content/themes/point/functions.php
@@ -61,7 +61,7 @@ add_filter( 'render_block_core/site-logo', 'retraceur_render_default_logo' );
  */
 function retraceur_point_more_link() {
 	return sprintf(
-		'<p class="ensemble-more-link">
+		'<p class="more-link">
 			<a href="%1$s" class="more-link">%2$s &rarr;</a>
 		</p>',
 		esc_url( get_the_permalink() ),

--- a/wp-includes/blocks.php
+++ b/wp-includes/blocks.php
@@ -1492,16 +1492,23 @@ function truncate_raw_content_into_rest_response( $response, $post, $request ) {
 		$referer_path = wp_parse_url( $request->get_header( 'referer'), PHP_URL_PATH );
 
 		if ( '/wp-admin/site-editor.php' === $referer_path && ! empty( $response->data['content']['raw'] ) && has_block( 'more', $response->data['content']['raw'] ) ) {
-			$more_block    = get_comment_delimited_block_content( 'more', array(), "\n<!--more-->\n" );
-			$content_parts = explode( $more_block, $response->data['content']['raw'] );
+			$more_block = get_comment_delimited_block_content(
+				'core/more',
+				array(),
+				"\n<!--more-->\n"
+			);
 
+			$content_parts = explode( $more_block, $response->data['content']['raw'] );
 			if ( ! empty( $content_parts[0] ) ) {
-				$_post          = clone $post;
-				$_post->content = '<!--more-->';
-				$more_content   = wp_kses(
+				$_post               = clone $post;
+				$_post->post_content = '<!--more-->';
+
+				// Generate the "more link" making sure the 'the_content_more_link' filter is fired.
+				$more_content = wp_kses(
 					get_the_content( null, false, $_post ),
 					array(
 						'a'    => array(
+							'href'  => true,
 							'class' => true,
 						),
 						'span' => array(
@@ -1510,7 +1517,14 @@ function truncate_raw_content_into_rest_response( $response, $post, $request ) {
 					)
 				);
 
-				$response->data['content']['raw'] = $content_parts[0] . get_comment_delimited_block_content( 'paragraph', array(), $more_content );
+				// Wrap the "more link" inside a paragraph.
+				$more_paragraph = get_comment_delimited_block_content(
+					'core/paragraph',
+					array(),
+					$more_content
+				);
+
+				$response->data['content']['raw'] = $content_parts[0] . $more_paragraph;
 			}
 		}
 	}

--- a/wp-includes/blocks.php
+++ b/wp-includes/blocks.php
@@ -1478,6 +1478,47 @@ function insert_hooked_blocks_into_rest_response( $response, $post ) {
 }
 
 /**
+ * Honour Post content's "read-more" mechanism in Site Editor's edited archive templates.
+ *
+ * @since 2.0.0 Retraceur fork.
+ *
+ * @param WP_REST_Response $response The response object.
+ * @param WP_Post          $post     Post object.
+ * @param WP_REST_Request  $request  Request object.
+ * @return WP_REST_Response The response object.
+ */
+function truncate_raw_content_into_rest_response( $response, $post, $request ) {
+	if ( $request instanceof WP_REST_Request ) {
+		$referer_path = wp_parse_url( $request->get_header( 'referer'), PHP_URL_PATH );
+
+		if ( '/wp-admin/site-editor.php' === $referer_path && ! empty( $response->data['content']['raw'] ) && has_block( 'more', $response->data['content']['raw'] ) ) {
+			$more_block    = get_comment_delimited_block_content( 'more', array(), "\n<!--more-->\n" );
+			$content_parts = explode( $more_block, $response->data['content']['raw'] );
+
+			if ( ! empty( $content_parts[0] ) ) {
+				$_post          = clone $post;
+				$_post->content = '<!--more-->';
+				$more_content   = wp_kses(
+					get_the_content( null, false, $_post ),
+					array(
+						'a'    => array(
+							'class' => true,
+						),
+						'span' => array(
+							'class' => true,
+						),
+					)
+				);
+
+				$response->data['content']['raw'] = $content_parts[0] . get_comment_delimited_block_content( 'paragraph', array(), $more_content );
+			}
+		}
+	}
+
+	return $response;
+}
+
+/**
  * Returns a function that injects the theme attribute into, and hooked blocks before, a given block.
  *
  * The returned function can be used as `$pre_callback` argument to `traverse_and_serialize_block(s)`,

--- a/wp-includes/default-filters.php
+++ b/wp-includes/default-filters.php
@@ -674,4 +674,7 @@ add_filter( 'rest_prepare_post', 'insert_hooked_blocks_into_rest_response', 10, 
 add_filter( 'rest_prepare_wp_block', 'insert_hooked_blocks_into_rest_response', 10, 2 );
 add_filter( 'rest_prepare_wp_navigation', 'insert_hooked_blocks_into_rest_response', 10, 2 );
 
+// Honour Post content's "read-more" mechanism in Site Editor's edited archive templates.
+add_filter( 'rest_prepare_post', 'truncate_raw_content_into_rest_response', 9, 3 );
+
 unset( $filter, $action );


### PR DESCRIPTION
Editing a loop template (eg: index.html) inside the Site Editor is not interpreting the "core/more" block as it should (or like it's done on front-end).

This PR is fixing the issue.

Fixes #103