### PR TITLE
Set post format to be `standard` for the Latest Posts widget

### DIFF
--- a/wp-includes/blocks/latest-posts.php
+++ b/wp-includes/blocks/latest-posts.php
@@ -48,6 +48,7 @@ function render_block_core_latest_posts( $attributes ) {
 	$args = array(
 		'posts_per_page'      => $attributes['postsToShow'],
 		'post_status'         => 'publish',
+		'post_format'         => 'post-format-standard',
 		'order'               => $attributes['order'],
 		'orderby'             => $attributes['orderBy'],
 		'ignore_sticky_posts' => true,

--- a/wp-includes/js/dist/block-library.js
+++ b/wp-includes/js/dist/block-library.js
@@ -24579,6 +24579,7 @@ ${url}
             orderby: orderBy,
             per_page: postsToShow,
             _embed: "author,wp:featuredmedia",
+						format: 'standard',
             ignore_sticky: true
           }).filter(([, value]) => typeof value !== "undefined")
         );


### PR DESCRIPTION
Todo: update the `block-library` package.

See #133