### PR TITLE
Make sure the `og:title` property is consistent with the document title

### DIFF
--- a/wp-includes/general-template.php
+++ b/wp-includes/general-template.php
@@ -1276,6 +1276,22 @@ function wp_get_document_title() {
 	 */
 	$title = apply_filters( 'document_title_parts', $title );
 
+	/**
+	 * Fires once the document title parts are fully set.
+	 *
+	 * @since 3.0.0 Retraceur fork.
+	 *
+	 * @param array $title {
+	 *     The document title parts.
+	 *
+	 *     @type string $title   Title of the viewed page.
+	 *     @type string $page    Optional. Page number if paginated.
+	 *     @type string $tagline Optional. Site description when on home page.
+	 *     @type string $site    Optional. Site title when not on home page.
+	 * }
+	 */
+	do_action( 'defined_title_parts', $title );
+
 	$title = implode( " $sep ", array_filter( $title ) );
 
 	/**

--- a/wp-includes/opengraph/class-retraceur-opengraph-manager.php
+++ b/wp-includes/opengraph/class-retraceur-opengraph-manager.php
@@ -87,7 +87,7 @@ class Retraceur_Opengraph_Manager {
 	}
 
 	/**
-	 * Registers needed Hooks to render the Opengraph meta tags.
+	 * Registers needed hooks to render the Opengraph meta tags.
 	 *
 	 * @since 3.0.0 Retraceur fork.
 	 */

--- a/wp-includes/opengraph/class-retraceur-opengraph-manager.php
+++ b/wp-includes/opengraph/class-retraceur-opengraph-manager.php
@@ -34,6 +34,15 @@ class Retraceur_Opengraph_Manager {
 	private Retraceur_Opengraph_Renderer $renderer;
 
 	/**
+	 * The document title parts.
+	 *
+	 * @since 3.0.0 Retraceur fork.
+	 *
+	 * @var array
+	 */
+	public array $title_parts = array();
+
+	/**
 	 * Retraceur Opengraph manager constructor.
 	 *
 	 * @since 3.0.0 Retraceur fork.
@@ -44,12 +53,25 @@ class Retraceur_Opengraph_Manager {
 	}
 
 	/**
-	 * Hooks to `wp_head` to render the Opengraph meta tags.
+	 * Sets the title parts property.
+	 *
+	 * The title is first set by `wp_get_document_title()` inside its title parts array,
+	 * using this value makes sure the `og:title` property will be consistent with the
+	 * `<title>` tag.
 	 *
 	 * @since 3.0.0 Retraceur fork.
+	 *
+	 * @param array $title_parts {
+	 *     The document title parts.
+	 *
+	 *     @type string $title   Title of the viewed page.
+	 *     @type string $page    Optional. Page number if paginated.
+	 *     @type string $tagline Optional. Site description when on home page.
+	 *     @type string $site    Optional. Site title when not on home page.
+	 * }
 	 */
-	public function register() {
-		add_action( 'wp_head', array( $this, 'render' ), 10 );
+	public function set_title_parts( $title_parts = array() ) {
+		$this->title_parts = $title_parts;
 	}
 
 	/**
@@ -60,6 +82,17 @@ class Retraceur_Opengraph_Manager {
 	 * @return void
 	 */
 	public function render() {
+		$opengraph = $this->resolver->resolve( $this->title_parts );
 		return;
+	}
+
+	/**
+	 * Registers needed Hooks to render the Opengraph meta tags.
+	 *
+	 * @since 3.0.0 Retraceur fork.
+	 */
+	public function register() {
+		add_action( 'defined_title_parts', array( $this, 'set_title_parts' ), 10, 1 );
+		add_action( 'wp_head', array( $this, 'render' ), 10 );
 	}
 }

--- a/wp-includes/opengraph/class-retraceur-opengraph-resolver.php
+++ b/wp-includes/opengraph/class-retraceur-opengraph-resolver.php
@@ -95,17 +95,18 @@ class Retraceur_Opengraph_Resolver {
 	 *
 	 * @since 3.0.0 Retraceur fork.
 	 *
+	 * @param string $title Optional. The document title if available.
 	 * @return string The `title` property of the Retraceur Opengraph context.
 	 */
-	public function resolve_title() {
-		$title = '';
+	public function resolve_title( $title = '' ) {
 
-		if ( is_singular() ) {
-			$title = get_the_title();
-		}
-
+		// Only resolve the title if it wasn't resolved by `wp_get_document_title()`.
 		if ( empty( $title ) ) {
-			$title = get_bloginfo( 'name' );
+			if ( is_singular() ) {
+				$title = get_the_title();
+			} else {
+				$title = get_bloginfo( 'name', 'display' );
+			}
 		}
 
 		/**
@@ -139,14 +140,14 @@ class Retraceur_Opengraph_Resolver {
 				$description = $post->post_content;
 			}
 		} else {
-			$description = get_bloginfo( 'description' );
+			$description = get_bloginfo( 'description', 'display' );
 		}
 
 		if ( empty( $description) ) {
 			$description = sprintf(
 				/* Translators: %s is the Website name. */
 				_x( 'A %s website’s page.', 'Default Opengraph description' ),
-				get_bloginfo( 'name' )
+				get_bloginfo( 'name', 'display' )
 			);
 		}
 
@@ -194,24 +195,32 @@ class Retraceur_Opengraph_Resolver {
 	}
 
 	/**
-	 * Resolves the basic part of the Retraceur Opengraph context.
+	 * Resolves the site properties of the Retraceur Opengraph context.
 	 *
 	 * @since 3.0.0 Retraceur fork.
 	 *
-	 * @param Retraceur_Opengraph_Context $context The Opengraph context object.
+	 * @param Retraceur_Opengraph_Context $context     The Opengraph context object.
+	 * @param array                       $title_parts Optional. The document title parts.
 	 */
-	private function resolve_basic_properties( Retraceur_Opengraph_Context $context ) {
+	private function resolve_site_properties( Retraceur_Opengraph_Context $context, $title_parts = array() ) {
+		$title = '';
+
+		// Use the title's document title part if available.
+		if ( ! empty( $title_parts['title'] ) ) {
+			$title = $title_parts['title'];
+		}
+
 		$context->type        = $this->resolve_type();
 		$context->url         = $this->resolve_url();
-		$context->site_name   = get_bloginfo( 'name' );
-		$context->title       = $this->resolve_title();
+		$context->site_name   = ! empty( $title_parts['site'] ) ? $title_parts['site'] : get_bloginfo( 'name', 'display' );
+		$context->title       = $this->resolve_title( $title );
 		$context->description = $this->resolve_description();
 		$context->image       = $this->resolve_image();
 		$context->locale      = get_locale();
 	}
 
 	/**
-	 * Resolves the detailed part of the Retraceur Opengraph context.
+	 * Resolves the article properties of the Retraceur Opengraph context.
 	 *
 	 * @since 3.0.0 Retraceur fork.
 	 *
@@ -226,9 +235,10 @@ class Retraceur_Opengraph_Resolver {
 	 *
 	 * @since 3.0.0 Retraceur fork.
 	 *
+	 * @param array $title_parts Optional. The document title parts.
 	 * @return Retraceur_Opengraph_Context|null The valid Opengraph context object. `null` when it is invalid.
 	 */
-	public function resolve() {
+	public function resolve( $title_parts = array() ) {
 		$skip = $this->should_skip();
 
 		/**
@@ -244,7 +254,7 @@ class Retraceur_Opengraph_Resolver {
 
 		$context = new Retraceur_Opengraph_Context();
 
-		$this->resolve_basic_properties( $context );
+		$this->resolve_site_properties( $context, $title_parts );
 
 		if ( $context->type === 'article' ) {
 			$this->resolve_article_properties( $context );


### PR DESCRIPTION
Introduce a new hook (`defined_title_parts`)  inside the `wp_get_document_title()` function once the document title parts are fully set (including potential edits made by third parties filtering `document_title_parts`).

Enjoy these title parts within the Retraceur Opengraph API to make sure the `og:title` is consistent with the `<title>` tag.

See #144