### PR TITLE
Adds a new image size: opengraph

### DIFF
--- a/wp-includes/media.php
+++ b/wp-includes/media.php
@@ -5682,9 +5682,12 @@ function wp_media_personal_data_exporter( $email_address, $page = 1 ) {
  * The size "names" reflect the image dimensions, so changing the sizes would be quite misleading.
  *
  * @since WP 5.3.0
+ * @since 3.0.0 Retraceur fork Adds the Open Graph image size.
  * @access private
  */
 function _wp_add_additional_image_sizes() {
+	// Open Graph image size.
+	add_image_size( 'opengraph', 1200, 630, true );
 	// 2x medium_large size.
 	add_image_size( '1536x1536', 1536, 1536 );
 	// 2x large size.

--- a/wp-includes/opengraph.php
+++ b/wp-includes/opengraph.php
@@ -74,7 +74,7 @@ function retraceur_get_opengraph_url( $blog_id = 0 ) {
 	$og_image_id = (int) get_option( 'default_ogengraph_image' );
 
 	if ( $og_image_id ) {
-		$url = wp_get_attachment_image_url( $og_image_id, 'full' );
+		$url = wp_get_attachment_image_url( $og_image_id, 'opengraph' );
 	}
 
 	if ( $switched_blog ) {

--- a/wp-includes/opengraph/class-retraceur-opengraph-resolver.php
+++ b/wp-includes/opengraph/class-retraceur-opengraph-resolver.php
@@ -197,7 +197,7 @@ class Retraceur_Opengraph_Resolver {
 		$image = '';
 
 		if ( is_singular() && has_post_thumbnail() ) {
-			$image = get_the_post_thumbnail_url( null, 'full' );
+			$image = get_the_post_thumbnail_url( null, 'opengraph' );
 		}
 
 		if ( empty( $image ) ) {


### PR DESCRIPTION
This image size doesn't need to be customizable, so it's simply added to Retraceur intermediate ones.

Fixes #149