### PR TITLE
Make sure `undo-manager` package is not deleted during upgrade

### DIFF
--- a/wp-admin/includes/update-core.php
+++ b/wp-admin/includes/update-core.php
@@ -89,8 +89,6 @@ $_old_files = array(
 	'wp-includes/blocks/post-template/editor.min.css',
 	'wp-includes/blocks/post-template/editor-rtl.css',
 	'wp-includes/blocks/post-template/editor-rtl.min.css',
-	'wp-includes/js/dist/undo-manager.js',
-	'wp-includes/js/dist/undo-manager.min.js',
 	'wp-includes/js/dist/fields.min.js',
 	'wp-includes/js/dist/fields.js',
 	// 6.9


### PR DESCRIPTION
As WP 6.8 added this package files to the `$_old_files` global, the part of the upgrade process that removes files that are no more included into a release was doing its job although we are now using a separate `undo-manager` package in 3.0.0.

Fixes #160