### PR TITLE
Apply `the_content` filters when the post_content is used as `og:description`

### DIFF
--- a/wp-includes/opengraph/class-retraceur-opengraph-resolver.php
+++ b/wp-includes/opengraph/class-retraceur-opengraph-resolver.php
@@ -139,7 +139,8 @@ class Retraceur_Opengraph_Resolver {
 			if ( ! empty( $post->post_excerpt ) ) {
 				$description = $post->post_excerpt;
 			} else {
-				$description = $post->post_content;
+				/** This filter is documented in wp-includes/post-template.php */
+				$description = apply_filters( 'the_content', $post->post_content );
 			}
 		} else {
 			// Defaults to site's tagline.


### PR DESCRIPTION
This makes sure blocks are rendered inside the `og:description` property.

Fixes #164