### PR TITLE
Deprecate `WP_HTTP_IXR_Client`

### DIFF
--- a/wp-includes/class-wp-http-ixr-client.php
+++ b/wp-includes/class-wp-http-ixr-client.php
@@ -4,126 +4,18 @@
  *
  * @since WP 3.1.0
  * @since 1.0.0 Retraceur fork.
+ * @deprecated 4.0.0 Retraceur fork.
  *
  * @package Retraceur
  */
-#[AllowDynamicProperties]
-class WP_HTTP_IXR_Client extends IXR_Client {
-	public $scheme;
-	/**
-	 * @var IXR_Error
-	 */
-	public $error;
 
-	/**
-	 * @param string       $server
-	 * @param string|false $path
-	 * @param int|false    $port
-	 * @param int          $timeout
-	 */
-	public function __construct( $server, $path = false, $port = false, $timeout = 15 ) {
-		if ( ! $path ) {
-			// Assume we have been given a URL instead.
-			$bits         = parse_url( $server );
-			$this->scheme = $bits['scheme'] ?? '';
-			$this->server = $bits['host'] ?? '';
-			$this->port   = $bits['port'] ?? $port;
-			$this->path   = $bits['path'] ?? '/';
+/** Include the bootstrap for setting up Retraceur environment */
+require_once '../wp-load.php';
 
-			// Make absolutely sure we have a path.
-			if ( ! $this->path ) {
-				$this->path = '/';
-			}
+_deprecated_file( basename( __FILE__ ), '4.0.0', '', '', true );
 
-			if ( ! empty( $bits['query'] ) ) {
-				$this->path .= '?' . $bits['query'];
-			}
-		} else {
-			$this->scheme = 'http';
-			$this->server = $server;
-			$this->path   = $path;
-			$this->port   = $port;
-		}
-		$this->useragent = 'The Incutio XML-RPC PHP Library';
-		$this->timeout   = $timeout;
-	}
-
-	/**
-	 * @since WP 3.1.0
-	 * @since WP 5.5.0 Formalized the existing `...$args` parameter by adding it
-	 *              to the function signature.
-	 *
-	 * @return bool True if the request succeeded, false otherwise.
-	 */
-	public function query( ...$args ) {
-		$method  = array_shift( $args );
-		$request = new IXR_Request( $method, $args );
-		$xml     = $request->getXml();
-
-		$port = $this->port ? ":$this->port" : '';
-		$url  = $this->scheme . '://' . $this->server . $port . $this->path;
-		$args = array(
-			'headers'    => array( 'Content-Type' => 'text/xml' ),
-			'user-agent' => $this->useragent,
-			'body'       => $xml,
-		);
-
-		// Merge Custom headers ala #8145.
-		foreach ( $this->headers as $header => $value ) {
-			$args['headers'][ $header ] = $value;
-		}
-
-		/**
-		 * Filters the headers collection to be sent to the XML-RPC server.
-		 *
-		 * @since WP 4.4.0
-		 *
-		 * @param string[] $headers Associative array of headers to be sent.
-		 */
-		$args['headers'] = apply_filters( 'wp_http_ixr_client_headers', $args['headers'] );
-
-		if ( false !== $this->timeout ) {
-			$args['timeout'] = $this->timeout;
-		}
-
-		// Now send the request.
-		if ( $this->debug ) {
-			echo '<pre class="ixr_request">' . htmlspecialchars( $xml ) . "\n</pre>\n\n";
-		}
-
-		$response = wp_safe_remote_post( $url, $args );
-
-		if ( is_wp_error( $response ) ) {
-			$errno       = $response->get_error_code();
-			$errorstr    = $response->get_error_message();
-			$this->error = new IXR_Error( -32300, "transport error: $errno $errorstr" );
-			return false;
-		}
-
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			$this->error = new IXR_Error( -32301, 'transport error - HTTP status code was not 200 (' . wp_remote_retrieve_response_code( $response ) . ')' );
-			return false;
-		}
-
-		if ( $this->debug ) {
-			echo '<pre class="ixr_response">' . htmlspecialchars( wp_remote_retrieve_body( $response ) ) . "\n</pre>\n\n";
-		}
-
-		// Now parse what we've got back.
-		$this->message = new IXR_Message( wp_remote_retrieve_body( $response ) );
-		if ( ! $this->message->parse() ) {
-			// XML error.
-			$this->error = new IXR_Error( -32700, 'parse error. not well formed' );
-			return false;
-		}
-
-		// Is the message a fault?
-		if ( 'fault' === $this->message->messageType ) {
-			$this->error = new IXR_Error( $this->message->faultCode, $this->message->faultString );
-			return false;
-		}
-
-		// Message must be OK.
-		return true;
-	}
-}
+wp_die(
+	'<h1>' . __( 'Retraceur does not provide a XML-RPC API.' ) . '</h1>' .
+	'<p>' . __( 'Use the REST API instead.' ) . '</p>',
+	500
+);


### PR DESCRIPTION
It has been moved into Reactions plugin.

See https://github.com/retraceur/reactions/issues/5
See #181
Fixes #182