### PR TITLE
Upgrade/Install: Verify GitHub release asset checksums on download.

### DIFF
--- a/wp-admin/includes/class-wp-upgrader.php
+++ b/wp-admin/includes/class-wp-upgrader.php
@@ -334,12 +334,51 @@ class WP_Upgrader {
 			return new WP_Error( 'no_package', $this->strings['no_package'] );
 		}
 
+		$expected_digest = '';
+		if ( preg_match( '#^https://github\.com/([^/]+/[^/]+)/releases/download/([^/]+)/(.+\.zip)$#', $package, $m ) ) {
+			list( , $owner_repo, $tag, $asset_name ) = $m;
+
+			$digest_request = wp_remote_get(
+				"https://api.github.com/repos/{$owner_repo}/releases/tags/{$tag}",
+				array(
+					'headers' => array(
+						'Accept' => 'application/vnd.github+json'
+					)
+				)
+			);
+
+			if ( ! is_wp_error( $digest_request ) && 200 === wp_remote_retrieve_response_code( $digest_request ) ) {
+				$release = json_decode( wp_remote_retrieve_body( $digest_request ), true );
+
+				if ( ! empty( $release['assets'] ) ) {
+					foreach ( $release['assets'] as $asset ) {
+						if ( isset( $asset['name'] ) && $asset['name'] === $asset_name ) {
+							$expected_digest = $asset['digest'] ?? '';
+							break;
+						}
+					}
+				}
+			}
+		}
+
 		$this->skin->feedback( 'downloading_package', $package );
 
 		$download_file = download_url( $package, 300, $check_signatures );
 
 		if ( is_wp_error( $download_file ) && ! $download_file->get_error_data( 'softfail-filename' ) ) {
 			return new WP_Error( 'download_failed', $this->strings['download_failed'], $download_file->get_error_message() );
+		}
+
+		if ( $expected_digest
+			&& is_string( $download_file )
+			&& ! hash_equals( $expected_digest, 'sha256:' . hash_file( 'sha256', $download_file ) )
+		) {
+			wp_delete_file( $download_file );
+
+			return new WP_Error(
+				'retraceur_checksum_mismatch',
+				__( 'Checksum verification failed. Update cancelled.' )
+			);
 		}
 
 		return $download_file;


### PR DESCRIPTION
When a package resolves to a GitHub release asset, `WP_Upgrader::download_package()` now retrieves the SHA-256 digest that GitHub computes for uploaded assets and verifies the downloaded ZIP against it before the package reaches the installer. The expected digest is read from the releases REST API for the matching tag and asset name; after download, the file hash is compared with `hash_equals()` and, on mismatch, the file is deleted and the update aborts with an error.

Verification is skipped when no digest is available — assets predating the GitHub feature, or an unreachable API — so authors who do not ship a digest yet are not blocked. This is a transitional, integrity-focused check: it detects tampering or corruption in transit, not maintainer-level authenticity, and is meant to become mandatory once digests are widely published.

As it lives in the shared download path, it protects plugins and blocks today, and themes once they are wired to the GitHub updater, in place of the wp.org package signature mechanism that Retraceur no longer relies on.

See #201.