### PR TITLE
Disable WP Plugin Dependencies checks for 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Changed
+
+- Temporarily disable the Plugin Dependencies feature, which relied on the WP.org Plugin Install API. The dependency checks are turned off (a plugin declaring a `Requires Plugins` header can be activated) until the distant dependency is replaced by a GitHub.com-based mechanism. See [#205](https://github.com/retraceur/coeur/issues/205).
+
+
 ## [3.1.0] - 2026-03-14
 
 ### Changed

--- a/wp-admin/plugins.php
+++ b/wp-admin/plugins.php
@@ -640,23 +640,38 @@ if ( current_user_can( 'install_plugins' ) ) {
 
 	unset( $tab_title );
 
-	$help  = '<p>' . esc_html__( 'Plugin or Block Dependencies aims to make the process of installing and activating add-ons (dependents) and the plugins or blocks they rely on (dependencies) consistent and easy.' ) . '</p>';
-
-	if ( 'block' === $plugins_type ) {
-		$help .= '<p>' . esc_html__( 'If a required block is deleted, a notice will be displayed on the Block administration screen informing the contributor that there is some missing dependencies to install and/or activate. Additionally, each block whose dependencies are not met will have an error notice on their block row.' ) . '</p>';
-		$help .= '<p>' . esc_html__( 'If a dependent block is missing some dependencies, its activation button will be disabled until the required dependencies are activated.' ) . '</p>';
-	} else {
-		$help .= '<p>' . esc_html__( 'If a required plugin is deleted, a notice will be displayed on the Plugin administration screen informing the contributor that there is some missing dependencies to install and/or activate. Additionally, each plugin whose dependencies are not met will have an error notice on their plugin row.' ) . '</p>';
-		$help .= '<p>' . esc_html__( 'If a dependent plugin is missing some dependencies, its activation button will be disabled until the required dependencies are activated.' ) . '</p>';
-	}
-
-	get_current_screen()->add_help_tab(
-		array(
-			'id'      => 'plugins-dependencies',
-			'title'   => __( 'Dependencies' ),
-			'content' => $help,
-		)
-	);
+	/*
+	 * Retraceur temporarily disabled the Plugin Dependencies feature in 4.0.0.
+	 *
+	 * This feature needs more work to be adapted to Retraceur's mindset:
+	 * - No dependency to WP dot org infrastructure.
+	 * - New mechanism to rely on GitHub.com.
+	 *
+	 * The related help tab is static content (not driven by dependency data), so
+	 * it would still be displayed even though the feature is disabled: it is
+	 * removed here until the feature is brought back.
+	 *
+	 * @todo Bring this back when ready:
+	 * $help  = '<p>' . esc_html__( 'Plugin or Block Dependencies aims to make the process of installing and activating add-ons (dependents) and the plugins or blocks they rely on (dependencies) consistent and easy.' ) . '</p>';
+	 *
+	 * 	if ( 'block' === $plugins_type ) {
+	 * 		$help .= '<p>' . esc_html__( 'If a required block is deleted, a notice will be displayed on the Block administration screen informing the contributor that there is some missing dependencies to install and/or activate. Additionally, each block whose dependencies are not met will have an error notice on their block row.' ) . '</p>';
+	 * 		$help .= '<p>' . esc_html__( 'If a dependent block is missing some dependencies, its activation button will be disabled until the required dependencies are activated.' ) . '</p>';
+	 * 	} else {
+	 * 		$help .= '<p>' . esc_html__( 'If a required plugin is deleted, a notice will be displayed on the Plugin administration screen informing the contributor that there is some missing dependencies to install and/or activate. Additionally, each plugin whose dependencies are not met will have an error notice on their plugin row.' ) . '</p>';
+	 * 		$help .= '<p>' . esc_html__( 'If a dependent plugin is missing some dependencies, its activation button will be disabled until the required dependencies are activated.' ) . '</p>';
+	 * 	}
+	 *
+	 * 	get_current_screen()->add_help_tab(
+	 * 		array(
+	 * 			'id'      => 'plugins-dependencies',
+	 * 			'title'   => __( 'Dependencies' ),
+	 * 			'content' => $help,
+	 * 		)
+	 * 	);
+	 *
+	 * @see https://github.com/retraceur/coeur/issues/205
+	 */
 }
 
 unset( $help );

--- a/wp-includes/class-wp-plugin-dependencies.php
+++ b/wp-includes/class-wp-plugin-dependencies.php
@@ -121,11 +121,31 @@ class WP_Plugin_Dependencies {
 	 * @since WP 6.5.0
 	 */
 	public static function initialize() {
+		/*
+		 * Retraceur temporarily disabled the Plugin Dependencies feature in 4.0.0.
+		 *
+		 * This feature needs more work to be adapted to Retraceur's mindset:
+		 * - No dependency to WP dot org infrastructure.
+		 * - New mechanism to rely on GitHub.com.
+		 *
+		 * Skipping initialization leaves the internal state empty, so every public
+		 * "has_*"/"get_*" method returns an empty/false value, the admin notices
+		 * render nothing and validate_plugin_requirements() no longer blocks the
+		 * activation of a plugin declaring a "Requires Plugins" header.
+		 *
+		 * @todo Bring this back when ready by removing the early return and the
+		 *       `phpcs:disable`/`phpcs:enable` pragmas below.
+		 * @see  https://github.com/retraceur/coeur/issues/205
+		 */
+		return;
+
+		// phpcs:disable Squiz.PHP.NonExecutableCode.Unreachable -- Preserved to restore the feature, see #205.
 		if ( false === self::$initialized ) {
 			self::read_dependencies_from_plugin_headers();
 			self::get_dependency_api_data();
 			self::$initialized = true;
 		}
+		// phpcs:enable Squiz.PHP.NonExecutableCode.Unreachable
 	}
 
 	/**


### PR DESCRIPTION
The Plugin Dependencies feature relied on the WP.org Plugin Install API. It needs more work to fit Retraceur's mindset (no WP.org infrastructure, GitHub.com-based mechanism) before it can be brought back.

Neutralize the feature at its single entry point by skipping `WP_Plugin_Dependencies::initialize()`. The internal state stays empty, so every public `has_*/get_*` method returns an `empty/false` value, the `unmet` and `circular` admin notices render nothing, the two AJAX paths report no required plugins, and `validate_plugin_requirements()` no longer blocks the activation of a plugin declaring a `'Requires Plugins' `header. The class call sites are left untouched and degrade to no-ops on their own.

The 'Dependencies' help tab on the Plugins screen is static content (not driven by dependency data), so it is commented out explicitly.

Fixes #205