### PR TITLE
Deprecate `get_core_checksums()`

### DIFF
--- a/wp-admin/includes/class-core-upgrader.php
+++ b/wp-admin/includes/class-core-upgrader.php
@@ -58,8 +58,6 @@ class Core_Upgrader extends WP_Upgrader {
 	 * @param array  $args {
 	 *     Optional. Arguments for upgrading Retraceur core. Default empty array.
 	 *
-	 *     @type bool $pre_check_md5    Whether to check the file checksums before
-	 *                                  attempting the upgrade. Default true.
 	 *     @type bool $attempt_rollback Whether to attempt to rollback the chances if
 	 *                                  there is a problem. Default false.
 	 *     @type bool $do_rollback      Whether to perform this "upgrade" as a rollback.
@@ -74,7 +72,6 @@ class Core_Upgrader extends WP_Upgrader {
 
 		$start_time  = time();
 		$defaults    = array(
-			'pre_check_md5'                => false,
 			'attempt_rollback'             => false,
 			'do_rollback'                  => false,
 			'allow_relaxed_file_ownership' => false,
@@ -279,6 +276,7 @@ class Core_Upgrader extends WP_Upgrader {
 	 * Compares the disk file checksums against the expected checksums.
 	 *
 	 * @since WP 3.7.0
+	 * @deprecated 4.0.0 Retraceur fork.
 	 *
 	 * @global string $retraceur_version The Retraceur version string.
 	 * @global string $wp_local_package  Locale code of the package.
@@ -288,22 +286,7 @@ class Core_Upgrader extends WP_Upgrader {
 	public function check_files() {
 		global $retraceur_version, $wp_local_package;
 
-		$checksums = get_core_checksums( $retraceur_version, $wp_local_package ?? 'en_US' );
-
-		if ( ! is_array( $checksums ) ) {
-			return false;
-		}
-
-		foreach ( $checksums as $file => $checksum ) {
-			// Skip files which get updated.
-			if ( str_starts_with( $file, 'wp-content' ) ) {
-				continue;
-			}
-			if ( ! file_exists( ABSPATH . $file ) || md5_file( ABSPATH . $file ) !== $checksum ) {
-				return false;
-			}
-		}
-
-		return true;
+		_deprecated_function( __METHOD__, '4.0.0', '', true );
+		return false;
 	}
 }

--- a/wp-admin/includes/deprecated.php
+++ b/wp-admin/includes/deprecated.php
@@ -4343,7 +4343,7 @@ function wp_ajax_toggle_auto_updates() {
  * Gets and caches the checksums for the given version of Retraceur.
  *
  * @since WP 3.7.0
- * @since 1.0.0 etraceur fork disabled the function.
+ * @since 1.0.0 Retraceur fork disabled the function.
  * @deprecated 4.0.0 Retraceur fork.
  *
  * @param string $version Version string to query.

--- a/wp-admin/includes/deprecated.php
+++ b/wp-admin/includes/deprecated.php
@@ -4338,3 +4338,19 @@ function wp_ajax_toggle_auto_updates() {
 
 	wp_send_json_error( array( 'error' => __( 'The WP Automatic Updates feature is not supported by the Retraceur fork.' ) ) );
 }
+
+/**
+ * Gets and caches the checksums for the given version of Retraceur.
+ *
+ * @since WP 3.7.0
+ * @since 1.0.0 etraceur fork disabled the function.
+ * @deprecated 4.0.0 Retraceur fork.
+ *
+ * @param string $version Version string to query.
+ * @param string $locale  Locale to query.
+ * @return array<string, string>|false An array of checksums on success, false on failure.
+ */
+function get_core_checksums( $version, $locale ) {
+	_deprecated_function( __FUNCTION__, '4.0.0', '', true );
+	return false;
+}

--- a/wp-admin/includes/update-core.php
+++ b/wp-admin/includes/update-core.php
@@ -365,37 +365,7 @@ function update_core( $from, $to ) {
 	 * Don't copy wp-content, we'll deal with that below.
 	 * We also copy version.php last so failed updates report their old version.
 	 */
-	$skip              = array( 'wp-content', 'wp-includes/version.php' );
-	$check_is_writable = array();
-
-	// If we're using the direct method, we can predict write failures that are due to permissions.
-	if ( $check_is_writable && 'direct' === $wp_filesystem->method ) {
-		$files_writable = array_filter( $check_is_writable, array( $wp_filesystem, 'is_writable' ) );
-
-		if ( $files_writable !== $check_is_writable ) {
-			$files_not_writable = array_diff_key( $check_is_writable, $files_writable );
-
-			foreach ( $files_not_writable as $relative_file_not_writable => $file_not_writable ) {
-				// If the writable check failed, chmod file to 0644 and try again, same as copy_dir().
-				$wp_filesystem->chmod( $file_not_writable, FS_CHMOD_FILE );
-
-				if ( $wp_filesystem->is_writable( $file_not_writable ) ) {
-					unset( $files_not_writable[ $relative_file_not_writable ] );
-				}
-			}
-
-			// Store package-relative paths (the key) of non-writable files in the WP_Error object.
-			$error_data = version_compare( $old_wp_version, '3.7-beta2', '>' ) ? array_keys( $files_not_writable ) : '';
-
-			if ( $files_not_writable ) {
-				return new WP_Error(
-					'files_not_writable',
-					__( 'The update cannot be installed because your site is unable to copy some files. This is usually due to inconsistent file permissions.' ),
-					implode( ', ', $error_data )
-				);
-			}
-		}
-	}
+	$skip = array( 'wp-content', 'wp-includes/version.php' );
 
 	/** This filter is documented in wp-admin/includes/update-core.php */
 	apply_filters( 'update_feedback', __( 'Enabling Maintenance mode&#8230;' ) );
@@ -439,41 +409,6 @@ function update_core( $from, $to ) {
 		 */
 		if ( function_exists( 'wp_opcache_invalidate' ) ) {
 			wp_opcache_invalidate( $to . 'wp-includes/version.php' );
-		}
-	}
-
-	// Check to make sure everything copied correctly, ignoring the contents of wp-content.
-	$skip   = array( 'wp-content' );
-	$failed = array();
-
-	// Some files didn't copy properly.
-	if ( ! empty( $failed ) ) {
-		$total_size = 0;
-
-		foreach ( $failed as $file ) {
-			if ( file_exists( $working_dir_local . $file ) ) {
-				$total_size += filesize( $working_dir_local . $file );
-			}
-		}
-
-		/*
-		 * If we don't have enough free space, it isn't worth trying again.
-		 * Unlikely to be hit due to the check in unzip_file().
-		 */
-		$available_space = function_exists( 'disk_free_space' ) ? @disk_free_space( ABSPATH ) : false;
-
-		if ( $available_space && $total_size >= $available_space ) {
-			$result = new WP_Error( 'disk_full', __( 'There is not enough free disk space to complete the update.' ) );
-		} else {
-			$result = copy_dir( $from . $distro, $to, $skip );
-
-			if ( is_wp_error( $result ) ) {
-				$result = new WP_Error(
-					$result->get_error_code() . '_retry',
-					$result->get_error_message(),
-					substr( $result->get_error_data(), strlen( $to ) )
-				);
-			}
 		}
 	}
 

--- a/wp-admin/includes/update-core.php
+++ b/wp-admin/includes/update-core.php
@@ -368,51 +368,6 @@ function update_core( $from, $to ) {
 	$skip              = array( 'wp-content', 'wp-includes/version.php' );
 	$check_is_writable = array();
 
-	// Check to see which files don't really need updating - only available for 3.7 and higher.
-	if ( function_exists( 'get_core_checksums' ) ) {
-		// Find the local version of the working directory.
-		$working_dir_local = WP_CONTENT_DIR . '/upgrade/' . basename( $from ) . $distro;
-
-		$checksums = get_core_checksums( $retraceur_version, $wp_local_package ?? 'en_US' );
-
-		if ( is_array( $checksums ) && isset( $checksums[ $retraceur_version ] ) ) {
-			$checksums = $checksums[ $retraceur_version ]; // Compat code for 3.7-beta2.
-		}
-
-		if ( is_array( $checksums ) ) {
-			foreach ( $checksums as $file => $checksum ) {
-				/*
-				 * Note: str_starts_with() is not used here, as this file is included
-				 * when updating from older Retraceur versions, in which case
-				 * the polyfills from wp-includes/compat.php may not be available.
-				 */
-				if ( 'wp-content' === substr( $file, 0, 10 ) ) {
-					continue;
-				}
-
-				if ( ! file_exists( ABSPATH . $file ) ) {
-					continue;
-				}
-
-				if ( ! file_exists( $working_dir_local . $file ) ) {
-					continue;
-				}
-
-				if ( '.' === dirname( $file )
-					&& in_array( pathinfo( $file, PATHINFO_EXTENSION ), array( 'html', 'txt' ), true )
-				) {
-					continue;
-				}
-
-				if ( md5_file( ABSPATH . $file ) === $checksum ) {
-					$skip[] = $file;
-				} else {
-					$check_is_writable[ $file ] = ABSPATH . $file;
-				}
-			}
-		}
-	}
-
 	// If we're using the direct method, we can predict write failures that are due to permissions.
 	if ( $check_is_writable && 'direct' === $wp_filesystem->method ) {
 		$files_writable = array_filter( $check_is_writable, array( $wp_filesystem, 'is_writable' ) );
@@ -490,36 +445,6 @@ function update_core( $from, $to ) {
 	// Check to make sure everything copied correctly, ignoring the contents of wp-content.
 	$skip   = array( 'wp-content' );
 	$failed = array();
-
-	if ( isset( $checksums ) && is_array( $checksums ) ) {
-		foreach ( $checksums as $file => $checksum ) {
-			/*
-			 * Note: str_starts_with() is not used here, as this file is included
-			 * when updating from older Retraceur versions, in which case
-			 * the polyfills from wp-includes/compat.php may not be available.
-			 */
-			if ( 'wp-content' === substr( $file, 0, 10 ) ) {
-				continue;
-			}
-
-			if ( ! file_exists( $working_dir_local . $file ) ) {
-				continue;
-			}
-
-			if ( '.' === dirname( $file )
-				&& in_array( pathinfo( $file, PATHINFO_EXTENSION ), array( 'html', 'txt' ), true )
-			) {
-				$skip[] = $file;
-				continue;
-			}
-
-			if ( file_exists( ABSPATH . $file ) && md5_file( ABSPATH . $file ) === $checksum ) {
-				$skip[] = $file;
-			} else {
-				$failed[] = $file;
-			}
-		}
-	}
 
 	// Some files didn't copy properly.
 	if ( ! empty( $failed ) ) {

--- a/wp-admin/includes/update.php
+++ b/wp-admin/includes/update.php
@@ -80,59 +80,6 @@ function retraceur_get_updates( $options = array() ) {
 }
 
 /**
- * Gets and caches the checksums for the given version of Retraceur.
- *
- * @since WP 3.7.0
- * @since 1.0.0 Disable Core auto update for now.
- *
- * @param string $version Version string to query.
- * @param string $locale  Locale to query.
- * @return array<string, string>|false An array of checksums on success, false on failure.
- */
-function get_core_checksums( $version, $locale ) {
-	return false;
-
-	// @todo See what's possible to achieve here.
-	$http_url = '';
-	$url      = $http_url;
-
-	$ssl = wp_http_supports( array( 'ssl' ) );
-
-	if ( $ssl ) {
-		$url = set_url_scheme( $url, 'https' );
-	}
-
-	$options = array(
-		'timeout' => wp_doing_cron() ? 30 : 3,
-	);
-
-	$response = wp_remote_get( $url, $options );
-
-	if ( $ssl && is_wp_error( $response ) ) {
-		wp_trigger_error(
-			__FUNCTION__,
-			__( 'An unexpected error occurred. Something may be wrong with this server&#8217;s configuration.' ) . ' ' . __( '(Retraceur could not establish a secure connection to Core Update API. Please contact your server administrator.)' ),
-			headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
-		);
-
-		$response = wp_remote_get( $http_url, $options );
-	}
-
-	if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-		return false;
-	}
-
-	$body = trim( wp_remote_retrieve_body( $response ) );
-	$body = json_decode( $body, true );
-
-	if ( ! is_array( $body ) || ! isset( $body['checksums'] ) || ! is_array( $body['checksums'] ) ) {
-		return false;
-	}
-
-	return $body['checksums'];
-}
-
-/**
  * Marks a Retraceur coeur update as dismissed.
  *
  * @since 2.0.0 Retraceur fork.


### PR DESCRIPTION
This specific integrity check is not used by Retraceur anymore.

See #201