### PR TITLE
`WP_REST_URL_Details_Controller`: the `og:description` is a meta property

### DIFF
--- a/wp-includes/rest-api/endpoints/class-wp-rest-url-details-controller.php
+++ b/wp-includes/rest-api/endpoints/class-wp-rest-url-details-controller.php
@@ -366,12 +366,20 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$description = $this->get_metadata_from_meta_element(
 			$meta_elements,
 			'name',
-			'(?:description|og:description)'
+			'(?:description)'
 		);
 
-		// Bail out if description not found.
+		// Try out the `og:description` property if not found.
 		if ( '' === $description ) {
-			return '';
+			$description = $this->get_metadata_from_meta_element(
+				$meta_elements,
+				'property',
+				'(?:og:description)'
+			);
+
+			if ( empty( $description ) ) {
+				return '';
+			}
 		}
 
 		return $this->prepare_metadata_for_output( $description );


### PR DESCRIPTION
Make sure `WP_REST_URL_Details_Controller::parse_url_details()` looks for a property instead of the name when checking the `og:description` text.

Fixes #232